### PR TITLE
fix: fix calc current period spent amount, update calc period start

### DIFF
--- a/modules/motions/ui/MotionLimitProgress/MotionLimitProgress.tsx
+++ b/modules/motions/ui/MotionLimitProgress/MotionLimitProgress.tsx
@@ -32,7 +32,9 @@ export function MotionLimitProgress(props: MotionLimitProgressProps) {
   } = props
 
   const isValidNewValue = Number.isInteger(newAmount)
-  const newSpentValue = isValidNewValue ? Number(spentAmount) + newAmount : 0
+  const newSpentValue = isValidNewValue
+    ? Number(spentAmount) + newAmount
+    : Number(spentAmount)
 
   const progressPercent = clamp(
     Number(spentAmount) / (Number(totalLimit) / 100),


### PR DESCRIPTION

### Description

Fix of the problem of incorrect calculation of the amount spent during the motion period

### Testing notes

Check motion period limit statistic (period duration, period spent amount)

### Checklist:

- [X] Checked the changes locally.
