### PR TITLE
Fix walletconnect child-src csp

### DIFF
--- a/modules/shared/utils/csp.ts
+++ b/modules/shared/utils/csp.ts
@@ -36,7 +36,12 @@ export const contentSecurityPolicy = {
     frameAncestors: ['*'],
     manifestSrc: ["'self'", ...trustedHosts],
     mediaSrc: ["'self'", ...trustedHosts],
-    childSrc: ["'self'", ...trustedHosts],
+    childSrc: [
+      "'self'",
+      'https://*.walletconnect.org',
+      'https://*.walletconnect.com',
+      ...trustedHosts,
+    ],
     objectSrc: ["'self'", ...trustedHosts],
     defaultSrc: ["'self'", ...trustedHosts],
     baseUri: ["'none'"],


### PR DESCRIPTION
### Description

<img width="563" alt="Screenshot 2023-06-29 at 12 37 34" src="https://github.com/lidofinance/staking-widget-ts/assets/103929444/1ef6a4c6-d29d-4842-9a6d-5876992e6451">

### Review notes

For some reason, walletconnect wants to embed an iframe

<img width="576" alt="image" src="https://github.com/lidofinance/staking-widget-ts/assets/103929444/1dd159db-bc90-46f9-9e92-217c04c87f92">
