### PR TITLE
fix: object/enact transaction state moved to motion detailed provider

### DIFF
--- a/modules/motions/ui/MotionDetailed/MotionCardDetailed.tsx
+++ b/modules/motions/ui/MotionDetailed/MotionCardDetailed.tsx
@@ -151,9 +151,7 @@ export function MotionCardDetailed({ motion, onInvalidate }: Props) {
 
       <MotionDetailedLimits />
 
-      {!isArchived && (
-        <MotionDetailedActions motion={motion} onFinish={onInvalidate} />
-      )}
+      {!isArchived && <MotionDetailedActions motion={motion} />}
     </Card>
   )
 }

--- a/pages/motions/[motionId].tsx
+++ b/pages/motions/[motionId].tsx
@@ -56,7 +56,7 @@ export default function MotionDetailsPage() {
 
   return (
     <ContentContainer>
-      <MotionDetailedProvider motion={motion}>
+      <MotionDetailedProvider motion={motion} onInvalidate={revalidate}>
         <MotionCardDetailed motion={motion} onInvalidate={revalidate} />
       </MotionDetailedProvider>
     </ContentContainer>


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description
Fixing error when motion page was losing enact/objection transaction state

### Checklist:

- [x] Checked the changes locally.
