### PR TITLE
Top up limit scale for floats

### DIFF
--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewAllowedRecipientTopUp.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewAllowedRecipientTopUp.tsx
@@ -16,7 +16,7 @@ import {
 } from 'modules/motions/ui/MotionLimitProgress'
 
 import { PageLoader } from 'modules/shared/ui/Common/PageLoader'
-import { InputControl } from 'modules/shared/ui/Controls/Input'
+import { InputNumberControl } from 'modules/shared/ui/Controls/InputNumber'
 import { SelectControl, Option } from 'modules/shared/ui/Controls/Select'
 import { MotionInfoBox } from 'modules/shared/ui/Common/MotionInfoBox'
 import {
@@ -221,7 +221,7 @@ export const formParts = ({
                 </Fieldset>
 
                 <Fieldset>
-                  <InputControl
+                  <InputNumberControl
                     label={`${token.label} Amount`}
                     name={`${fieldNames.programs}.${i}.amount`}
                     rules={{

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewNodeOperators.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewNodeOperators.tsx
@@ -8,6 +8,7 @@ import { useNodeOperatorKeysInfo } from 'modules/motions/hooks/useNodeOperatorKe
 import { KeysInfoBlock } from 'modules/motions/ui/KeysInfoBlock'
 import { PageLoader } from 'modules/shared/ui/Common/PageLoader'
 import { InputControl } from 'modules/shared/ui/Controls/Input'
+import { InputNumberControl } from 'modules/shared/ui/Controls/InputNumber'
 import { Fieldset, MessageBox } from '../CreateMotionFormStyle'
 
 import { MotionType } from 'modules/motions/types'
@@ -113,7 +114,7 @@ export const formParts = createMotionFormPart({
         </Fieldset>
 
         <Fieldset>
-          <InputControl
+          <InputNumberControl
             name={fieldNames.newLimit}
             label={
               currentNodeOperator ? (

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
@@ -16,7 +16,7 @@ import {
 } from 'modules/motions/ui/MotionLimitProgress'
 
 import { PageLoader } from 'modules/shared/ui/Common/PageLoader'
-import { InputControl } from 'modules/shared/ui/Controls/Input'
+import { InputNumberControl } from 'modules/shared/ui/Controls/InputNumber'
 import { SelectControl, Option } from 'modules/shared/ui/Controls/Select'
 import { MotionInfoBox } from 'modules/shared/ui/Common/MotionInfoBox'
 import {
@@ -230,7 +230,7 @@ export const formParts = ({
                 </Fieldset>
 
                 <Fieldset>
-                  <InputControl
+                  <InputNumberControl
                     label={`${token.label} Amount`}
                     name={`${fieldNames.programs}.${i}.amount`}
                     autoFocus

--- a/modules/motions/ui/MotionLimitProgress/MotionLimitProgress.tsx
+++ b/modules/motions/ui/MotionLimitProgress/MotionLimitProgress.tsx
@@ -31,7 +31,7 @@ export function MotionLimitProgress(props: MotionLimitProgressProps) {
     showAmountChange,
   } = props
 
-  const isValidNewValue = Number.isInteger(newAmount)
+  const isValidNewValue = !Number.isNaN(Number(newAmount))
   const newSpentValue = isValidNewValue
     ? Number(spentAmount) + newAmount
     : Number(spentAmount)

--- a/modules/shared/ui/Controls/InputNumber/InputNumber.tsx
+++ b/modules/shared/ui/Controls/InputNumber/InputNumber.tsx
@@ -1,0 +1,32 @@
+import { forwardRef, useCallback } from 'react'
+import { Input } from '@lidofinance/lido-ui'
+import { withFormController } from 'modules/shared/hocs/withFormController'
+
+type Props = React.ComponentProps<typeof Input>
+
+export const InputNumber = forwardRef<HTMLInputElement, Props>(
+  ({ onChange, ...props }, ref) => {
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        // Prepend zero when user types just a dot symbol for "0."
+        if (e.currentTarget.value === '.') {
+          e.currentTarget.value = '0.'
+          onChange?.(e)
+          return
+        }
+
+        if (isNaN(Number(e.target.value))) {
+          return
+        }
+
+        onChange?.(e)
+      },
+      [onChange],
+    )
+    return <Input {...props} ref={ref} onChange={handleChange} />
+  },
+)
+
+InputNumber.displayName = 'InputNumber'
+
+export const InputNumberControl = withFormController(InputNumber)

--- a/modules/shared/ui/Controls/InputNumber/index.ts
+++ b/modules/shared/ui/Controls/InputNumber/index.ts
@@ -1,0 +1,1 @@
+export * from './InputNumber'


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

Fixing a problem was occurring when top-up amount is not integer and top-up limit scale was not filled.
Also number-filtered input was added, reference: https://github.com/lidofinance/ethereum-staking-widget/blob/develop/shared/forms/components/input-number/input-number.tsx

### Checklist:

- [x] Checked the changes locally.
