### PR TITLE
fix: hide new wallets

### DIFF
--- a/modules/wallet/ui/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/modules/wallet/ui/ConnectWalletModal/ConnectWalletModal.tsx
@@ -21,6 +21,9 @@ const HIDDEN_WALLETS: WalletModalForEthProps['hiddenWallets'] = [
   'tally',
   'zengo',
   'zerion',
+  'bitget',
+  'bitkeep',
+  'taho',
 ]
 
 type Props = WalletModalForEthProps & {}


### PR DESCRIPTION
### Description

Hide wallets that appear after SDK update.

### Checklist:

- [x] Checked the changes locally.
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
