### PR TITLE
feat: add holesky chain config for WalletConnect

### DIFF
--- a/modules/appWagmiConfig/appWagmiConfig.tsx
+++ b/modules/appWagmiConfig/appWagmiConfig.tsx
@@ -1,11 +1,37 @@
 import { FC } from 'react'
-import { WagmiConfig, configureChains, createClient } from 'wagmi'
+import { configureChains, createClient, WagmiConfig } from 'wagmi'
 import * as wagmiChains from 'wagmi/chains'
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
 import { getConnectors } from 'reef-knot/core-react'
 import getConfig from 'next/config'
 import { CHAINS } from '@lido-sdk/constants'
 import { getBackendRpcUrl } from 'modules/blockChain/utils/getBackendRpcUrl'
+
+export const holesky = {
+  id: CHAINS.Holesky,
+  name: 'Holesky',
+  network: 'holesky',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'holeskyETH',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    public: { http: [getBackendRpcUrl(CHAINS.Holesky)] },
+    default: { http: [getBackendRpcUrl(CHAINS.Holesky)] },
+  },
+  blockExplorers: {
+    etherscan: { name: 'holesky', url: 'https://holesky.etherscan.io/' },
+    default: { name: 'holesky', url: 'https://holesky.etherscan.io/' },
+  },
+  testnet: true,
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 77,
+    },
+  },
+} as const
 
 const { publicRuntimeConfig } = getConfig()
 
@@ -19,7 +45,11 @@ if (publicRuntimeConfig.supportedChains != null) {
   supportedChainIds = [parseInt(publicRuntimeConfig.defaultChain)]
 }
 
-const wagmiChainsArray = Object.values(wagmiChains)
+const wagmiChainsArray = Object.values({
+  ...wagmiChains,
+  [CHAINS.Holesky]: holesky,
+})
+
 const supportedChains = wagmiChainsArray.filter(
   chain =>
     // Temporary wagmi fix, need to hardcode it to not affect non-wagmi wallets

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "lint-staged": "13.1.0",
     "prettier": "2.5.1",
     "type-fest": "2.12.0",
-    "typescript": "^4.9.4",
+    "typescript": "^4.9.5",
     "url-loader": "4.1.1",
     "utility-types": "3.10.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10330,7 +10330,7 @@ typedarray-to-buffer@3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.6.4, typescript@^4.9.4:
+typescript@^4.6.4, typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
### Description

Add config for WalletConnect holesky

safe app adress:
https://stg.holesky-safe.protofire.io/

### Checklist:

- [x] Checked the changes locally.
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
