### PR TITLE
feat: Holesky top up motions

### DIFF
--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -38,6 +38,7 @@ export const STETH: ChainAddressMap = {
 export const DAI: ChainAddressMap = {
   [CHAINS.Mainnet]: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
   [CHAINS.Goerli]: '0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844',
+  [CHAINS.Holesky]: '0x2eb8e9198e647f80ccf62a5e291bcd4a5a3ca68c',
 }
 
 export const Finance: ChainAddressMap = {
@@ -136,4 +137,12 @@ export const SandboxNodeOperatorsRegistry: ChainAddressMap = {
 
 export const AllowedTokensRegistry: ChainAddressMap = {
   [CHAINS.Goerli]: '0xeda5a9F02a580B4A879aEA65E2a7B7fEc0956b0E',
+}
+
+export const SandboxStablesAllowedTokensRegistry: ChainAddressMap = {
+  [CHAINS.Holesky]: '0x091c0ec8b4d54a9fcb36269b5d5e5af43309e666',
+}
+
+export const SandboxStablesAllowedRecipientRegistry: ChainAddressMap = {
+  [CHAINS.Holesky]: '0xF8a63a36B954D72de197097377aa00C238c653Cf',
 }

--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -59,16 +59,19 @@ export const AllowedRecipientReferralDaiRegistry: ChainAddressMap = {
 export const AllowedRecipientTrpLdoRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0x231Ac69A1A37649C6B06a71Ab32DdD92158C80b8',
   [CHAINS.Goerli]: '0x8C96a6522aEc036C4a384f8B7e05D93d6f3Dae39',
+  [CHAINS.Holesky]: '0x5f4E9A917d6556dB91Cf351f49b0edCc5A255bAE',
 }
 
 export const LegoLDORegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0x97615f72c3428A393d65A84A3ea6BBD9ad6C0D74',
   [CHAINS.Goerli]: '0x6342213719839c56fEe817539863aFB9821B03cb',
+  [CHAINS.Holesky]: '0x77CF728329920E4191a6Edd9b009cD055D3cD29A',
 }
 
 export const LegoDAIRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xb0FE4D300334461523D9d61AaD90D0494e1Abb43',
   [CHAINS.Goerli]: '0x5884f5849414D4317d175fEc144e2F87f699B082',
+  [CHAINS.Holesky]: '0x10Ff9c02C65775379D9E20BFF9AC92Cbaf15Ab8F',
 }
 
 export const RccStablesRegistry: ChainAddressMap = {
@@ -95,11 +98,13 @@ export const gasFunderETHRegistry: ChainAddressMap = {
 export const StethRewardProgramRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0x48c4929630099b217136b64089E8543dB0E5163a',
   [CHAINS.Goerli]: '0x78797efCca6C537BF92FA6b25cBb14A6f1c128A0',
+  [CHAINS.Holesky]: '0x55B304a585D540421F1fD3579Ef12Abab7304492',
 }
 
 export const StethGasSupplyRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0x49d1363016aA899bba09ae972a1BF200dDf8C55F',
   [CHAINS.Goerli]: '0xF08a5f00824D4554a1FBebaE726609418dc819fb',
+  [CHAINS.Holesky]: '0x1B68a7BeE396e2eaAD9D2716E0A271A4BB568BCd',
 }
 
 export const AragonACL: ChainAddressMap = {
@@ -117,6 +122,7 @@ export const EVMScriptExecutor: ChainAddressMap = {
 export const RewardsShareProgramRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xdc7300622948a7AdaF339783F6991F9cdDD79776',
   [CHAINS.Goerli]: '0x8b59609f4bEa230E565Ae0C3C7b6913746Df1cF2',
+  [CHAINS.Holesky]: '0xAc2F596191c75B77c2835Afe83c3a9097f0AC071',
 }
 
 export const SDVTRegistry: ChainAddressMap = {

--- a/modules/blockChain/contracts.ts
+++ b/modules/blockChain/contracts.ts
@@ -369,3 +369,30 @@ export const ContractEvmAtcStablesTopUp = createContractHelpers({
   factory: TypeChain.TopUpWithLimitsStablesAbi__factory,
   address: EvmAddressesByType[MotionType.AtcStablesTopUp],
 })
+
+export const ContractSandboxStablesAllowedRecipientRegistry =
+  createContractHelpers({
+    factory: TypeChain.RegistryWithLimitsAbi__factory,
+    address: CONTRACT_ADDRESSES.SandboxStablesAllowedRecipientRegistry,
+  })
+
+export const ContractSandboxStablesAllowedTokensRegistry =
+  createContractHelpers({
+    factory: TypeChain.AllowedTokensRegistryAbi__factory,
+    address: CONTRACT_ADDRESSES.SandboxStablesAllowedTokensRegistry,
+  })
+
+export const ContractEvmSandboxStablesAdd = createContractHelpers({
+  factory: TypeChain.AddAllowedRecipientAbi__factory,
+  address: EvmAddressesByType[MotionType.SandboxStablesAdd],
+})
+
+export const ContractEvmSandboxStablesRemove = createContractHelpers({
+  factory: TypeChain.RemoveAllowedRecipientAbi__factory,
+  address: EvmAddressesByType[MotionType.SandboxStablesRemove],
+})
+
+export const ContractEvmSandboxStablesTopUp = createContractHelpers({
+  factory: TypeChain.TopUpWithLimitsStablesAbi__factory,
+  address: EvmAddressesByType[MotionType.SandboxStablesTopUp],
+})

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -159,18 +159,28 @@ export const EvmAddressesByChain: EvmAddresses = {
   [CHAINS.Holesky]: {
     [MotionType.NodeOperatorIncreaseLimit]:
       '0x18Ff3bD97739bf910cDCDb8d138976c6afDB4449',
-    [MotionType.AllowedRecipientTopUpTrpLdo]: '',
-    [MotionType.LegoLDOTopUp]: '',
-    [MotionType.LegoDAITopUp]: '',
-    [MotionType.StethRewardProgramAdd]: '',
-    [MotionType.StethRewardProgramRemove]: '',
-    [MotionType.StethRewardProgramTopUp]: '',
-    [MotionType.StethGasSupplyAdd]: '',
-    [MotionType.StethGasSupplyRemove]: '',
-    [MotionType.StethGasSupplyTopUp]: '',
-    [MotionType.RewardsShareProgramAdd]: '',
-    [MotionType.RewardsShareProgramRemove]: '',
-    [MotionType.RewardsShareProgramTopUp]: '',
+    [MotionType.AllowedRecipientTopUpTrpLdo]:
+      '0xD618F0CF48F057B5256e102dC18d8011e08c19D3',
+    [MotionType.LegoLDOTopUp]: '0xCfaFcD35ACcc4383e2CCDf7DD3F58114914F1955',
+    [MotionType.LegoDAITopUp]: '0xBCcfe42cc3EF530db9888dC8F82B1B4A4DfB9DB4',
+    [MotionType.StethRewardProgramAdd]:
+      '0xf0968B9bE18282dD23bbbC79a1c9C8996CE6984D',
+    [MotionType.StethRewardProgramRemove]:
+      '0xF0F34b82241cD49BB3952149BD30A08Eb9D8B54E',
+    [MotionType.StethRewardProgramTopUp]:
+      '0xBB06DD9a3C7eE8cE093860094e769a1E3D6F97F6',
+    [MotionType.StethGasSupplyAdd]:
+      '0x13dB9E1ddE54d2641f571EA288D9e79C0E8bce2e',
+    [MotionType.StethGasSupplyRemove]:
+      '0x64CE36D2DC7e7786BF56D2DF8A5F3c788977Fb19',
+    [MotionType.StethGasSupplyTopUp]:
+      '0xf97E048A952d170d5D5E817C8D9c8253f4D50F96',
+    [MotionType.RewardsShareProgramAdd]:
+      '0x49D3211203e8E18B4e60F74C1126934da2520987',
+    [MotionType.RewardsShareProgramRemove]:
+      '0x112c48c4659A9a1d42a3e45EBc8e37B6150F2B0C',
+    [MotionType.RewardsShareProgramTopUp]:
+      '0x089bc04630c056D76fF4Ec172e752A7d5B855e16',
 
     [MotionType.SDVTNodeOperatorsAdd]:
       '0xeF5233A5bbF243149E35B353A73FFa8931FDA02b',

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -201,6 +201,12 @@ export const EvmAddressesByChain: EvmAddresses = {
 
     [MotionType.SandboxNodeOperatorIncreaseLimit]:
       '0xbD37e55748c6f4Ece637AeD3e278e7575346B587',
+    [MotionType.SandboxStablesAdd]:
+      '0xB238fB1e7c8da5da022140dA956Fc3052808fC56',
+    [MotionType.SandboxStablesRemove]:
+      '0x51c730af05777c4D3CcC8c8B80558F4D155bb7BF',
+    [MotionType.SandboxStablesTopUp]:
+      '0x71bcEf1f4E4945005e1D22d68F02085D5167ab43',
 
     // next motion factories are @deprecated
     // we are keeping them here to display history data

--- a/modules/motions/hooks/useContractEvmScript.ts
+++ b/modules/motions/hooks/useContractEvmScript.ts
@@ -69,6 +69,9 @@ export const EVM_CONTRACTS = {
   [MotionType.RccStablesTopUp]: CONTRACTS.ContractEvmRccStablesTopUp,
   [MotionType.PmlStablesTopUp]: CONTRACTS.ContractEvmPmlStablesTopUp,
   [MotionType.AtcStablesTopUp]: CONTRACTS.ContractEvmAtcStablesTopUp,
+  [MotionType.SandboxStablesAdd]: CONTRACTS.ContractEvmSandboxStablesAdd,
+  [MotionType.SandboxStablesTopUp]: CONTRACTS.ContractEvmSandboxStablesTopUp,
+  [MotionType.SandboxStablesRemove]: CONTRACTS.ContractEvmSandboxStablesRemove,
 } as const
 
 export function useContractEvmScript<T extends MotionType | EvmUnrecognized>(

--- a/modules/motions/hooks/useRegistryWithLimits.ts
+++ b/modules/motions/hooks/useRegistryWithLimits.ts
@@ -14,6 +14,7 @@ import {
   ContractStethGasSupplyRegistry,
   ContractRewardsShareProgramRegistry,
   ContractRccStablesRegistry,
+  ContractSandboxStablesAllowedRecipientRegistry,
 } from 'modules/blockChain/contracts'
 import { getEventsRecipientAdded } from 'modules/motions/utils'
 import { MotionType } from 'modules/motions/types'
@@ -55,6 +56,12 @@ export const REGISTRY_WITH_LIMITS_BY_MOTION_TYPE = {
   [MotionType.RccStablesTopUp]: ContractRccStablesRegistry,
   [MotionType.PmlStablesTopUp]: ContractPmlStablesRegistry,
   [MotionType.AtcStablesTopUp]: ContractAtcStablesRegistry,
+  [MotionType.SandboxStablesAdd]:
+    ContractSandboxStablesAllowedRecipientRegistry,
+  [MotionType.SandboxStablesRemove]:
+    ContractSandboxStablesAllowedRecipientRegistry,
+  [MotionType.SandboxStablesTopUp]:
+    ContractSandboxStablesAllowedRecipientRegistry,
 } as const
 
 type HookArgs = {

--- a/modules/motions/types.ts
+++ b/modules/motions/types.ts
@@ -33,6 +33,10 @@ export const MotionTypeForms = {
   SDVTNodeOperatorManagerChange: 'SDVTNodeOperatorManagerChange',
 
   SandboxNodeOperatorIncreaseLimit: 'SandboxNodeOperatorIncreaseLimit',
+
+  SandboxStablesTopUp: 'SandboxStablesTopUp',
+  SandboxStablesAdd: 'SandboxStablesAdd',
+  SandboxStablesRemove: 'SandboxStablesRemove',
 } as const
 // intentionally
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/motions/ui/MotionDescription/MotionDescription.tsx
+++ b/modules/motions/ui/MotionDescription/MotionDescription.tsx
@@ -250,6 +250,26 @@ const MOTION_DESCRIPTIONS = {
       registryType={MotionType.AtcStablesTopUp}
     />
   ),
+  [MotionType.SandboxStablesAdd]: (props: DescAllowedRecipientAddProps) => (
+    <DescAllowedRecipientAdd
+      {...props}
+      registryType={MotionType.SandboxStablesAdd}
+    />
+  ),
+  [MotionType.SandboxStablesRemove]: (
+    props: DescAllowedRecipientRemoveProps,
+  ) => (
+    <DescAllowedRecipientRemove
+      {...props}
+      registryType={MotionType.SandboxStablesRemove}
+    />
+  ),
+  [MotionType.SandboxStablesTopUp]: (props: GenericDescProps) => (
+    <DescTopUpWithLimitsAndCustomToken
+      {...props}
+      registryType={MotionType.SandboxStablesTopUp}
+    />
+  ),
 } as const
 
 type Props = {

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewAllowedRecipientAdd.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewAllowedRecipientAdd.tsx
@@ -11,6 +11,7 @@ import {
   ContractStethGasSupplyAdd,
   ContractStethRewardProgramAdd,
   ContractRewardsShareProgramAdd,
+  ContractEvmSandboxStablesAdd,
 } from 'modules/blockChain/contracts'
 import { MotionTypeForms } from 'modules/motions/types'
 import { createMotionFormPart } from './createMotionFormPart'
@@ -28,6 +29,10 @@ export const ALLOWED_RECIPIENT_ADD_MAP = {
   [MotionTypeForms.RewardsShareProgramAdd]: {
     evmContract: ContractRewardsShareProgramAdd,
     motionType: MotionTypeForms.RewardsShareProgramAdd,
+  },
+  [MotionTypeForms.SandboxStablesAdd]: {
+    evmContract: ContractEvmSandboxStablesAdd,
+    motionType: MotionTypeForms.SandboxStablesAdd,
   },
 }
 

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewAllowedRecipientRemove.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewAllowedRecipientRemove.tsx
@@ -10,6 +10,7 @@ import {
   ContractStethGasSupplyRemove,
   ContractStethRewardProgramRemove,
   ContractRewardsShareProgramRemove,
+  ContractEvmSandboxStablesRemove,
 } from 'modules/blockChain/contracts'
 import { MotionTypeForms } from 'modules/motions/types'
 import { createMotionFormPart } from './createMotionFormPart'
@@ -27,6 +28,10 @@ export const ALLOWED_RECIPIENT_REMOVE_MAP = {
   [MotionTypeForms.RewardsShareProgramRemove]: {
     evmContract: ContractRewardsShareProgramRemove,
     motionType: MotionTypeForms.RewardsShareProgramRemove,
+  },
+  [MotionTypeForms.SandboxStablesRemove]: {
+    evmContract: ContractEvmSandboxStablesRemove,
+    motionType: MotionTypeForms.SandboxStablesRemove,
   },
 }
 

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
@@ -28,6 +28,7 @@ import {
   ContractEvmRccStablesTopUp,
   ContractEvmPmlStablesTopUp,
   ContractEvmAtcStablesTopUp,
+  ContractEvmSandboxStablesTopUp,
 } from 'modules/blockChain/contracts'
 import { MotionType } from 'modules/motions/types'
 import { createMotionFormPart } from './createMotionFormPart'
@@ -55,6 +56,10 @@ export const TOPUP_WITH_LIMITS_MAP = {
   [MotionType.AtcStablesTopUp]: {
     evmContract: ContractEvmAtcStablesTopUp,
     motionType: MotionType.AtcStablesTopUp,
+  },
+  [MotionType.SandboxStablesTopUp]: {
+    evmContract: ContractEvmSandboxStablesTopUp,
+    motionType: MotionType.SandboxStablesTopUp,
   },
 }
 
@@ -110,7 +115,7 @@ export const formParts = ({
         allowedTokens,
         tokensDecimalsMap,
         initialLoading: isTokensDataLoading,
-      } = useAllowedTokens()
+      } = useAllowedTokens(registryType)
       const {
         data: periodLimitsData,
         initialLoading: isPeriodLimitsDataLoading,

--- a/modules/motions/ui/MotionFormStartNew/Parts/index.ts
+++ b/modules/motions/ui/MotionFormStartNew/Parts/index.ts
@@ -92,6 +92,16 @@ export const formParts = {
     StartNewNodeOperatorLimitIncrease.formParts({
       motionType: MotionTypeForms.SandboxNodeOperatorIncreaseLimit,
     }),
+  [MotionTypeForms.SandboxStablesAdd]: formAllowedRecipientAdd.formParts({
+    registryType: MotionTypeForms.SandboxStablesAdd,
+  }),
+  [MotionTypeForms.SandboxStablesRemove]: formAllowedRecipientRemove.formParts({
+    registryType: MotionTypeForms.SandboxStablesRemove,
+  }),
+  [MotionTypeForms.SandboxStablesTopUp]:
+    StartNewTopUpWithLimitsAndCustomToken.formParts({
+      registryType: MotionTypeForms.SandboxStablesTopUp,
+    }),
 } as const
 
 export type FormData = {

--- a/modules/motions/utils/getMotionTypeDisplayName.ts
+++ b/modules/motions/utils/getMotionTypeDisplayName.ts
@@ -59,6 +59,9 @@ export const MotionTypeDisplayNames: Record<
   [MotionType.RccDAITopUp]: 'Top up RCC DAI',
   [MotionType.PmlDAITopUp]: 'Top up PML DAI',
   [MotionType.AtcDAITopUp]: 'Top up ATC DAI',
+  [MotionType.SandboxStablesTopUp]: 'Top up sandbox stables',
+  [MotionType.SandboxStablesAdd]: 'Add sandbox stables recipient',
+  [MotionType.SandboxStablesRemove]: 'Remove sandbox stables recipient',
 } as const
 
 export function getMotionTypeDisplayName(


### PR DESCRIPTION
### Description

Add missing top-up motions on Holesky Testnet according to the recent [docs](https://docs.lido.fi/deployed-contracts/holesky#easy-track-factories-for-token-transfers) update. 

### Checklist:

- [x] Checked the changes locally.
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
