### PR TITLE
feat: replace public operator backend to private

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,3 +24,4 @@ SUBGRAPH_GOERLI=https://api.thegraph.com/subgraphs/name/lidofinance/lido-testnet
 SUBGRAPH_HOLESKY=https://api.thegraph.com/subgraphs/name/lidofinance/lido-testnet
 
 WALLETCONNECT_PROJECT_ID=
+OPERATORS_WIDGET_BACKEND_URL=

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,6 +32,7 @@ const subgraphGoerli = process.env.SUBGRAPH_GOERLI
 const subgraphHolesky = process.env.SUBGRAPH_HOLESKY
 
 const walletconnectProjectId = process.env.WALLETCONNECT_PROJECT_ID
+const operatorsWidgetBackendUrl = process.env.OPERATORS_WIDGET_BACKEND_URL
 
 export default {
   basePath,
@@ -126,6 +127,7 @@ export default {
     subgraphMainnet,
     subgraphGoerli,
     subgraphHolesky,
+    operatorsWidgetBackendUrl,
   },
   publicRuntimeConfig: {
     defaultChain,


### PR DESCRIPTION
### Description

Connect different operator api for Holesky and Mainnet

### Code review notes

For local require node-operator-widget-backend launch

### Testing notes

Motions with operator information

### Checklist:

- [x] Checked the changes locally.
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
