### PR TITLE
feat: update operator public API

### DIFF
--- a/pages/api/node-operators/keys-info.ts
+++ b/pages/api/node-operators/keys-info.ts
@@ -32,12 +32,6 @@ export type KeysInfoNew = {
   }
 }
 
-const requestMainnetOperators = async (chainId: number) => {
-  const data = await fetch(
-    `https://operators.lido.fi/api/operators?chainId=${chainId}`,
-  )
-  return data.json()
-}
 const requestTestnetOperators = async (chainId: number) => {
   const data = await fetch(
     `https://operators.testnet.fi/api/operators?chainId=${chainId}`,
@@ -45,12 +39,14 @@ const requestTestnetOperators = async (chainId: number) => {
   return data.json()
 }
 
-const requestHoleskyOperators = async (
+const requestOperators = async (
+  api:
+    | 'https://operators-holesky.testnet.fi/api'
+    | 'https://operators.lido.fi/api',
   chainId: number,
   moduleAddress: string,
   walletAddress: string,
 ) => {
-  const api = 'https://operators-holesky.testnet.fi/api'
   const modulesResp = await fetch(`${api}/modules?chainId=${chainId}`)
   const modules: Module[] = await modulesResp.json()
 
@@ -109,9 +105,15 @@ export default createNextConnect().get(async (req, res) => {
 
     let result
     if (chainId === CHAINS.Mainnet) {
-      result = await requestMainnetOperators(chainId)
+      result = await requestOperators(
+        'https://operators.lido.fi/api',
+        chainId,
+        moduleAddress,
+        walletAddress,
+      )
     } else if (chainId === CHAINS.Holesky) {
-      result = await requestHoleskyOperators(
+      result = await requestOperators(
+        'https://operators-holesky.testnet.fi/api',
         chainId,
         moduleAddress,
         walletAddress,


### PR DESCRIPTION
### Description

Move to new operators api. 
https://linear.app/lidofi/issue/VAL-448/deploy-node-operators-widget-ui-widget-backend
https://linear.app/lidofi/issue/DAO-188/migrate-et-ui-to-new-public-operators-api-at-mainnet

### Code review notes

Code works at holesky from start

### Testing notes

Operator names and key counts should be correct in motion and creation

### Checklist:

- [X] Checked the changes locally.
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
