### PR TITLE
feat: new top up factories

### DIFF
--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -69,7 +69,7 @@ export const LegoLDORegistry: ChainAddressMap = {
   [CHAINS.Holesky]: '0x77CF728329920E4191a6Edd9b009cD055D3cD29A',
 }
 
-export const LegoDAIRegistry: ChainAddressMap = {
+export const LegoStablesRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xb0FE4D300334461523D9d61AaD90D0494e1Abb43',
   [CHAINS.Goerli]: '0x5884f5849414D4317d175fEc144e2F87f699B082',
   [CHAINS.Holesky]: '0x10Ff9c02C65775379D9E20BFF9AC92Cbaf15Ab8F',

--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -78,16 +78,19 @@ export const LegoStablesRegistry: ChainAddressMap = {
 export const RccStablesRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xDc1A0C7849150f466F07d48b38eAA6cE99079f80',
   [CHAINS.Goerli]: '0x1440E8aDbE3a42a9EDB4b30059df8F6c35205a15',
+  [CHAINS.Holesky]: '0x17Ab17290bcDbea381500525A58e16e29093523c',
 }
 
 export const PmlStablesRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xDFfCD3BF14796a62a804c1B16F877Cf7120379dB',
   [CHAINS.Goerli]: '0xAadfBd1ADE92d85c967f4aE096141F0F802F46Db',
+  [CHAINS.Holesky]: '0x580B23a97F827F2b6E51B3DEc270Ef522Ccf520c',
 }
 
 export const AtcStablesRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xe07305F43B11F230EaA951002F6a55a16419B707',
   [CHAINS.Goerli]: '0xedD3B813275e1A88c2283FAfa5bf5396938ef59e',
+  [CHAINS.Holesky]: '0x37675423796D39C19351c5C322C3692b23a3d9bd',
 }
 
 export const gasFunderETHRegistry: ChainAddressMap = {

--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -136,6 +136,7 @@ export const SandboxNodeOperatorsRegistry: ChainAddressMap = {
 }
 
 export const AllowedTokensRegistry: ChainAddressMap = {
+  [CHAINS.Mainnet]: '0x4AC40c34f8992bb1e5E856A448792158022551ca',
   [CHAINS.Goerli]: '0xeda5a9F02a580B4A879aEA65E2a7B7fEc0956b0E',
 }
 

--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -138,9 +138,6 @@ export const SandboxNodeOperatorsRegistry: ChainAddressMap = {
 export const AllowedTokensRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0x4AC40c34f8992bb1e5E856A448792158022551ca',
   [CHAINS.Goerli]: '0xeda5a9F02a580B4A879aEA65E2a7B7fEc0956b0E',
-}
-
-export const SandboxStablesAllowedTokensRegistry: ChainAddressMap = {
   [CHAINS.Holesky]: '0x091c0ec8b4d54a9fcb36269b5d5e5af43309e666',
 }
 

--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -146,3 +146,18 @@ export const SandboxStablesAllowedTokensRegistry: ChainAddressMap = {
 export const SandboxStablesAllowedRecipientRegistry: ChainAddressMap = {
   [CHAINS.Holesky]: '0xF8a63a36B954D72de197097377aa00C238c653Cf',
 }
+
+export const RccStethAllowedRecipientsRegistry: ChainAddressMap = {
+  [CHAINS.Mainnet]: '0xAAC4FcE2c5d55D1152512fe5FAA94DB267EE4863',
+  [CHAINS.Holesky]: '0x916B909300c4aB5ADC4247cebd840C9278683e78',
+}
+
+export const PmlStethAllowedRecipientsRegistry: ChainAddressMap = {
+  [CHAINS.Mainnet]: '0x7b9B8d00f807663d46Fb07F87d61B79884BC335B',
+  [CHAINS.Holesky]: '0xC2Ec8a9285D111de54725FAD1AC6a3B7E3BC6225',
+}
+
+export const AtcStethAllowedRecipientsRegistry: ChainAddressMap = {
+  [CHAINS.Mainnet]: '0xd3950eB3d7A9B0aBf8515922c0d35D13e85a2c91',
+  [CHAINS.Holesky]: '0x955bA61676dAd6091Ff3F9BC498219D6DbD49107',
+}

--- a/modules/blockChain/contracts.ts
+++ b/modules/blockChain/contracts.ts
@@ -114,11 +114,17 @@ export const ContractEvmLegoLDOTopUp = createContractHelpers({
   address: EvmAddressesByType[MotionType.LegoLDOTopUp],
 })
 
+/**
+ * @deprecated
+ */
 export const ContractLegoDAIRegistry = createContractHelpers({
   factory: TypeChain.RegistryWithLimitsAbi__factory,
   address: CONTRACT_ADDRESSES.LegoDAIRegistry,
 })
 
+/**
+ * @deprecated
+ */
 export const ContractEvmLegoDAITopUp = createContractHelpers({
   factory: TypeChain.TopUpWithLimitsAbi__factory,
   address: EvmAddressesByType[MotionType.LegoDAITopUp],

--- a/modules/blockChain/contracts.ts
+++ b/modules/blockChain/contracts.ts
@@ -382,12 +382,6 @@ export const ContractSandboxStablesAllowedRecipientRegistry =
     address: CONTRACT_ADDRESSES.SandboxStablesAllowedRecipientRegistry,
   })
 
-export const ContractSandboxStablesAllowedTokensRegistry =
-  createContractHelpers({
-    factory: TypeChain.AllowedTokensRegistryAbi__factory,
-    address: CONTRACT_ADDRESSES.SandboxStablesAllowedTokensRegistry,
-  })
-
 export const ContractEvmSandboxStablesAdd = createContractHelpers({
   factory: TypeChain.AddAllowedRecipientAbi__factory,
   address: EvmAddressesByType[MotionType.SandboxStablesAdd],

--- a/modules/blockChain/contracts.ts
+++ b/modules/blockChain/contracts.ts
@@ -396,3 +396,33 @@ export const ContractEvmSandboxStablesTopUp = createContractHelpers({
   factory: TypeChain.TopUpWithLimitsStablesAbi__factory,
   address: EvmAddressesByType[MotionType.SandboxStablesTopUp],
 })
+
+export const ContractRccStethAllowedRecipientsRegistry = createContractHelpers({
+  factory: TypeChain.RegistryWithLimitsAbi__factory,
+  address: CONTRACT_ADDRESSES.RccStethAllowedRecipientsRegistry,
+})
+
+export const ContractPmlStethAllowedRecipientsRegistry = createContractHelpers({
+  factory: TypeChain.RegistryWithLimitsAbi__factory,
+  address: CONTRACT_ADDRESSES.PmlStethAllowedRecipientsRegistry,
+})
+
+export const ContractAtcStethAllowedRecipientsRegistry = createContractHelpers({
+  factory: TypeChain.RegistryWithLimitsAbi__factory,
+  address: CONTRACT_ADDRESSES.AtcStethAllowedRecipientsRegistry,
+})
+
+export const ContractRccStethTopUp = createContractHelpers({
+  factory: TypeChain.TopUpWithLimitsAbi__factory,
+  address: EvmAddressesByType[MotionType.RccStethTopUp],
+})
+
+export const ContractPmlStethTopUp = createContractHelpers({
+  factory: TypeChain.TopUpWithLimitsAbi__factory,
+  address: EvmAddressesByType[MotionType.PmlStethTopUp],
+})
+
+export const ContractAtcStethTopUp = createContractHelpers({
+  factory: TypeChain.TopUpWithLimitsAbi__factory,
+  address: EvmAddressesByType[MotionType.AtcStethTopUp],
+})

--- a/modules/blockChain/contracts.ts
+++ b/modules/blockChain/contracts.ts
@@ -114,12 +114,9 @@ export const ContractEvmLegoLDOTopUp = createContractHelpers({
   address: EvmAddressesByType[MotionType.LegoLDOTopUp],
 })
 
-/**
- * @deprecated
- */
-export const ContractLegoDAIRegistry = createContractHelpers({
+export const ContractLegoStablesRegistry = createContractHelpers({
   factory: TypeChain.RegistryWithLimitsAbi__factory,
-  address: CONTRACT_ADDRESSES.LegoDAIRegistry,
+  address: CONTRACT_ADDRESSES.LegoStablesRegistry,
 })
 
 /**
@@ -425,4 +422,9 @@ export const ContractPmlStethTopUp = createContractHelpers({
 export const ContractAtcStethTopUp = createContractHelpers({
   factory: TypeChain.TopUpWithLimitsAbi__factory,
   address: EvmAddressesByType[MotionType.AtcStethTopUp],
+})
+
+export const ContractLegoStablesTopUp = createContractHelpers({
+  factory: TypeChain.TopUpWithLimitsStablesAbi__factory,
+  address: EvmAddressesByType[MotionType.LegoStablesTopUp],
 })

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -48,6 +48,7 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.RccStablesTopUp]: '0x75bDecbb6453a901EBBB945215416561547dfDD4',
     [MotionType.PmlStablesTopUp]: '0x92a27C4e5e35cFEa112ACaB53851Ec70e2D99a8D',
     [MotionType.AtcStablesTopUp]: '0x1843Bc35d1fD15AbE1913b9f72852a79457C42Ab',
+    [MotionType.LegoStablesTopUp]: '0x6AB39a8Be67D9305799c3F8FdFc95Caf3150d17c',
 
     // next motion factories are @deprecated
     // we are keeping them here to display history data
@@ -215,7 +216,7 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.RccStethTopUp]: '0xe3bCa174A8b031C61a58aa56a0f622D4FFCA47d7',
     [MotionType.PmlStethTopUp]: '0x8612A51e4914FfFb25D96d1A310D4C6342c2091E',
     [MotionType.AtcStethTopUp]: '0x1395970895282333dC914172944f52F15Df63620',
-    [MotionType.LegoDAITopUp]: '0xBCcfe42cc3EF530db9888dC8F82B1B4A4DfB9DB4',
+    [MotionType.LegoStablesTopUp]: '0x7Bb5C5965a63aFb6a05D19bB03e3f170E2d7d684',
 
     // next motion factories are @deprecated
     // we are keeping them here to display history data
@@ -233,6 +234,7 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.AllowedRecipientAddReferralDai]: '',
     [MotionType.AllowedRecipientRemoveReferralDai]: '',
     [MotionType.AllowedRecipientTopUpReferralDai]: '',
+    [MotionType.LegoDAITopUp]: '0xBCcfe42cc3EF530db9888dC8F82B1B4A4DfB9DB4',
   },
 }
 

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -217,6 +217,9 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.PmlStethTopUp]: '0x8612A51e4914FfFb25D96d1A310D4C6342c2091E',
     [MotionType.AtcStethTopUp]: '0x1395970895282333dC914172944f52F15Df63620',
     [MotionType.LegoStablesTopUp]: '0x7Bb5C5965a63aFb6a05D19bB03e3f170E2d7d684',
+    [MotionType.RccStablesTopUp]: '0xD497E7e039FeFBc64dBB7b75368afb06D07Bc73F',
+    [MotionType.PmlStablesTopUp]: '0x5BAE56ECfB616eAbbDB048AC930FA1Db82f18900',
+    [MotionType.AtcStablesTopUp]: '0xfa54cf78474cD4A7f4408Dd0efA36e44b6269813',
 
     // next motion factories are @deprecated
     // we are keeping them here to display history data

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -75,6 +75,9 @@ export const EvmAddressesByChain: EvmAddresses = {
       '0xd8f9B72Cd97388f23814ECF429cd18815F6352c1',
     [MotionType.AllowedRecipientTopUpReferralDai]:
       '0x009ffa22ce4388d2F5De128Ca8E6fD229A312450',
+    [MotionType.RccStethTopUp]: '0xcD42Eb8a5db5a80Dc8f643745528DD77cf4C7D35',
+    [MotionType.PmlStethTopUp]: '0xc5527396DDC353BD05bBA578aDAa1f5b6c721136',
+    [MotionType.AtcStethTopUp]: '0x87b02dF27cd6ec128532Add7C8BC19f62E6f1fB9',
   },
 
   // Goerli
@@ -207,6 +210,9 @@ export const EvmAddressesByChain: EvmAddresses = {
       '0x51c730af05777c4D3CcC8c8B80558F4D155bb7BF',
     [MotionType.SandboxStablesTopUp]:
       '0x71bcEf1f4E4945005e1D22d68F02085D5167ab43',
+    [MotionType.RccStethTopUp]: '0xe3bCa174A8b031C61a58aa56a0f622D4FFCA47d7',
+    [MotionType.PmlStethTopUp]: '0x8612A51e4914FfFb25D96d1A310D4C6342c2091E',
+    [MotionType.AtcStethTopUp]: '0x1395970895282333dC914172944f52F15Df63620',
 
     // next motion factories are @deprecated
     // we are keeping them here to display history data

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -24,7 +24,6 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.AllowedRecipientTopUpTrpLdo]:
       '0xBd2b6dC189EefD51B273F5cb2d99BA1ce565fb8C',
     [MotionType.LegoLDOTopUp]: '0x00caAeF11EC545B192f16313F53912E453c91458',
-    [MotionType.LegoDAITopUp]: '0x0535a67ea2D6d46f85fE568B7EaA91Ca16824FEC',
     [MotionType.StethRewardProgramAdd]:
       '0x935cb3366Faf2cFC415B2099d1F974Fd27202b77',
     [MotionType.StethRewardProgramRemove]:
@@ -81,6 +80,7 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.RccDAITopUp]: '0x84f74733ede9bFD53c1B3Ea96338867C94EC313e',
     [MotionType.PmlDAITopUp]: '0x4E6D3A5023A38cE2C4c5456d3760357fD93A22cD',
     [MotionType.AtcDAITopUp]: '0x67Fb97ABB9035E2e93A7e3761a0d0571c5d7CD07',
+    [MotionType.LegoDAITopUp]: '0x0535a67ea2D6d46f85fE568B7EaA91Ca16824FEC',
   },
 
   // Goerli
@@ -90,7 +90,6 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.AllowedRecipientTopUpTrpLdo]:
       '0x43f33C52156d1Fb2eA24d82aBfD342E69835E79f',
     [MotionType.LegoLDOTopUp]: '0xc39Dd5B66968e364D99e0c9E7089049351AB89CA',
-    [MotionType.LegoDAITopUp]: '0xbf44eC2b23cA105F8a62e0587900a09A473288c6',
     [MotionType.RccStablesTopUp]: '0xd50eE42B31Bc500409B7caD99A2D16FB1Bfecdc6',
     [MotionType.PmlStablesTopUp]: '0x5F379512158A46ab7a91f8b799A97691eC498b9a',
     [MotionType.AtcStablesTopUp]: '0xB87300405050e7f1dBC35c6C9ce9ea4417D3Ad81',
@@ -159,6 +158,7 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.RccDAITopUp]: '0xd0411e7c4A24E7d4509D5F13AEd19aeb8e5644AB',
     [MotionType.PmlDAITopUp]: '0xc749aD24572263887Bc888d3Cb854FCD50eCCB61',
     [MotionType.AtcDAITopUp]: '0xF4b8b5760EE4b5c5Cb154edd0f0841465d821006',
+    [MotionType.LegoDAITopUp]: '0xbf44eC2b23cA105F8a62e0587900a09A473288c6',
   },
 
   // Holesky
@@ -168,7 +168,6 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.AllowedRecipientTopUpTrpLdo]:
       '0xD618F0CF48F057B5256e102dC18d8011e08c19D3',
     [MotionType.LegoLDOTopUp]: '0xCfaFcD35ACcc4383e2CCDf7DD3F58114914F1955',
-    [MotionType.LegoDAITopUp]: '0xBCcfe42cc3EF530db9888dC8F82B1B4A4DfB9DB4',
     [MotionType.StethRewardProgramAdd]:
       '0xf0968B9bE18282dD23bbbC79a1c9C8996CE6984D',
     [MotionType.StethRewardProgramRemove]:
@@ -216,6 +215,7 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.RccStethTopUp]: '0xe3bCa174A8b031C61a58aa56a0f622D4FFCA47d7',
     [MotionType.PmlStethTopUp]: '0x8612A51e4914FfFb25D96d1A310D4C6342c2091E',
     [MotionType.AtcStethTopUp]: '0x1395970895282333dC914172944f52F15Df63620',
+    [MotionType.LegoDAITopUp]: '0xBCcfe42cc3EF530db9888dC8F82B1B4A4DfB9DB4',
 
     // next motion factories are @deprecated
     // we are keeping them here to display history data

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -25,9 +25,6 @@ export const EvmAddressesByChain: EvmAddresses = {
       '0xBd2b6dC189EefD51B273F5cb2d99BA1ce565fb8C',
     [MotionType.LegoLDOTopUp]: '0x00caAeF11EC545B192f16313F53912E453c91458',
     [MotionType.LegoDAITopUp]: '0x0535a67ea2D6d46f85fE568B7EaA91Ca16824FEC',
-    [MotionType.RccDAITopUp]: '0x84f74733ede9bFD53c1B3Ea96338867C94EC313e',
-    [MotionType.PmlDAITopUp]: '0x4E6D3A5023A38cE2C4c5456d3760357fD93A22cD',
-    [MotionType.AtcDAITopUp]: '0x67Fb97ABB9035E2e93A7e3761a0d0571c5d7CD07',
     [MotionType.StethRewardProgramAdd]:
       '0x935cb3366Faf2cFC415B2099d1F974Fd27202b77',
     [MotionType.StethRewardProgramRemove]:
@@ -46,6 +43,12 @@ export const EvmAddressesByChain: EvmAddresses = {
       '0xd30Dc38EdEfc21875257e8A3123503075226E14B',
     [MotionType.RewardsShareProgramTopUp]:
       '0xbD08f9D6BF1D25Cc7407E4855dF1d46C2043B3Ea',
+    [MotionType.RccStethTopUp]: '0xcD42Eb8a5db5a80Dc8f643745528DD77cf4C7D35',
+    [MotionType.PmlStethTopUp]: '0xc5527396DDC353BD05bBA578aDAa1f5b6c721136',
+    [MotionType.AtcStethTopUp]: '0x87b02dF27cd6ec128532Add7C8BC19f62E6f1fB9',
+    [MotionType.RccStablesTopUp]: '0x75bDecbb6453a901EBBB945215416561547dfDD4',
+    [MotionType.PmlStablesTopUp]: '0x92a27C4e5e35cFEa112ACaB53851Ec70e2D99a8D',
+    [MotionType.AtcStablesTopUp]: '0x1843Bc35d1fD15AbE1913b9f72852a79457C42Ab',
 
     // next motion factories are @deprecated
     // we are keeping them here to display history data
@@ -75,9 +78,9 @@ export const EvmAddressesByChain: EvmAddresses = {
       '0xd8f9B72Cd97388f23814ECF429cd18815F6352c1',
     [MotionType.AllowedRecipientTopUpReferralDai]:
       '0x009ffa22ce4388d2F5De128Ca8E6fD229A312450',
-    [MotionType.RccStethTopUp]: '0xcD42Eb8a5db5a80Dc8f643745528DD77cf4C7D35',
-    [MotionType.PmlStethTopUp]: '0xc5527396DDC353BD05bBA578aDAa1f5b6c721136',
-    [MotionType.AtcStethTopUp]: '0x87b02dF27cd6ec128532Add7C8BC19f62E6f1fB9',
+    [MotionType.RccDAITopUp]: '0x84f74733ede9bFD53c1B3Ea96338867C94EC313e',
+    [MotionType.PmlDAITopUp]: '0x4E6D3A5023A38cE2C4c5456d3760357fD93A22cD',
+    [MotionType.AtcDAITopUp]: '0x67Fb97ABB9035E2e93A7e3761a0d0571c5d7CD07',
   },
 
   // Goerli
@@ -88,9 +91,6 @@ export const EvmAddressesByChain: EvmAddresses = {
       '0x43f33C52156d1Fb2eA24d82aBfD342E69835E79f',
     [MotionType.LegoLDOTopUp]: '0xc39Dd5B66968e364D99e0c9E7089049351AB89CA',
     [MotionType.LegoDAITopUp]: '0xbf44eC2b23cA105F8a62e0587900a09A473288c6',
-    [MotionType.RccDAITopUp]: '0xd0411e7c4A24E7d4509D5F13AEd19aeb8e5644AB',
-    [MotionType.PmlDAITopUp]: '0xc749aD24572263887Bc888d3Cb854FCD50eCCB61',
-    [MotionType.AtcDAITopUp]: '0xF4b8b5760EE4b5c5Cb154edd0f0841465d821006',
     [MotionType.RccStablesTopUp]: '0xd50eE42B31Bc500409B7caD99A2D16FB1Bfecdc6',
     [MotionType.PmlStablesTopUp]: '0x5F379512158A46ab7a91f8b799A97691eC498b9a',
     [MotionType.AtcStablesTopUp]: '0xB87300405050e7f1dBC35c6C9ce9ea4417D3Ad81',
@@ -156,6 +156,9 @@ export const EvmAddressesByChain: EvmAddresses = {
       '0x5FEC0bcd7519C4fE41eca5Fe1dD94345fA100A67',
     [MotionType.AllowedRecipientTopUpReferralDai]:
       '0x9534A77029D57E249c467E5A1E0854cc26Cd75A0',
+    [MotionType.RccDAITopUp]: '0xd0411e7c4A24E7d4509D5F13AEd19aeb8e5644AB',
+    [MotionType.PmlDAITopUp]: '0xc749aD24572263887Bc888d3Cb854FCD50eCCB61',
+    [MotionType.AtcDAITopUp]: '0xF4b8b5760EE4b5c5Cb154edd0f0841465d821006',
   },
 
   // Holesky

--- a/modules/motions/hooks/useAllowedTokensRegistry.ts
+++ b/modules/motions/hooks/useAllowedTokensRegistry.ts
@@ -1,32 +1,18 @@
-import {
-  ContractAllowedTokensRegistry,
-  ContractSandboxStablesAllowedTokensRegistry,
-} from 'modules/blockChain/contracts'
 import { useSWR } from 'modules/network/hooks/useSwr'
 import { useWeb3 } from 'modules/blockChain/hooks/useWeb3'
 import { connectERC20Contract } from '../utils/connectTokenContract'
-import { MotionType } from '../types'
+import { ContractAllowedTokensRegistry } from 'modules/blockChain/contracts'
 
-const TOKENS_REGISTRY_BY_MOTION_TYPE = {
-  [MotionType.AtcStablesTopUp]: ContractAllowedTokensRegistry,
-  [MotionType.PmlStablesTopUp]: ContractAllowedTokensRegistry,
-  [MotionType.RccStablesTopUp]: ContractAllowedTokensRegistry,
-  [MotionType.SandboxStablesTopUp]: ContractSandboxStablesAllowedTokensRegistry,
-}
-
-type RegistryType = keyof typeof TOKENS_REGISTRY_BY_MOTION_TYPE
-
-export function useAllowedTokens(registryType: RegistryType) {
+export function useAllowedTokens() {
   const { chainId, library } = useWeb3()
-  const registry = TOKENS_REGISTRY_BY_MOTION_TYPE[registryType].useRpc()
 
   const { data, initialLoading } = useSWR(
-    `allowed-tokens-${registryType}-${chainId}`,
+    `allowed-tokens-${chainId}`,
     async () => {
       if (!library) {
         return
       }
-
+      const registry = ContractAllowedTokensRegistry.connectRpc({ chainId })
       const tokensAddresses = await registry.getAllowedTokens()
 
       const allowedTokens = await Promise.all(

--- a/modules/motions/hooks/useContractEvmScript.ts
+++ b/modules/motions/hooks/useContractEvmScript.ts
@@ -72,6 +72,9 @@ export const EVM_CONTRACTS = {
   [MotionType.SandboxStablesAdd]: CONTRACTS.ContractEvmSandboxStablesAdd,
   [MotionType.SandboxStablesTopUp]: CONTRACTS.ContractEvmSandboxStablesTopUp,
   [MotionType.SandboxStablesRemove]: CONTRACTS.ContractEvmSandboxStablesRemove,
+  [MotionType.RccStethTopUp]: CONTRACTS.ContractRccStethTopUp,
+  [MotionType.PmlStethTopUp]: CONTRACTS.ContractPmlStethTopUp,
+  [MotionType.AtcStethTopUp]: CONTRACTS.ContractAtcStethTopUp,
 } as const
 
 export function useContractEvmScript<T extends MotionType | EvmUnrecognized>(

--- a/modules/motions/hooks/useContractEvmScript.ts
+++ b/modules/motions/hooks/useContractEvmScript.ts
@@ -75,6 +75,7 @@ export const EVM_CONTRACTS = {
   [MotionType.RccStethTopUp]: CONTRACTS.ContractRccStethTopUp,
   [MotionType.PmlStethTopUp]: CONTRACTS.ContractPmlStethTopUp,
   [MotionType.AtcStethTopUp]: CONTRACTS.ContractAtcStethTopUp,
+  [MotionType.LegoStablesTopUp]: CONTRACTS.ContractLegoStablesTopUp,
 } as const
 
 export function useContractEvmScript<T extends MotionType | EvmUnrecognized>(

--- a/modules/motions/hooks/useEVMScriptDecoder.ts
+++ b/modules/motions/hooks/useEVMScriptDecoder.ts
@@ -34,7 +34,7 @@ export function useEVMScriptDecoder() {
         [KEYS.AllowedRecipientTrpLdoRegistry]:
           abis.AllowedRecipientsRegistryAbi__factory.abi,
         [KEYS.LegoLDORegistry]: abis.RegistryWithLimitsAbi__factory.abi,
-        [KEYS.LegoDAIRegistry]: abis.RegistryWithLimitsAbi__factory.abi,
+        [KEYS.LegoStablesRegistry]: abis.RegistryWithLimitsAbi__factory.abi,
         [KEYS.RccStablesRegistry]: abis.RegistryWithLimitsAbi__factory.abi,
         [KEYS.PmlStablesRegistry]: abis.RegistryWithLimitsAbi__factory.abi,
         [KEYS.AtcStablesRegistry]: abis.RegistryWithLimitsAbi__factory.abi,

--- a/modules/motions/hooks/usePeriodLimitsInfo.ts
+++ b/modules/motions/hooks/usePeriodLimitsInfo.ts
@@ -106,6 +106,9 @@ const registryByMotionType: {
   [MotionType.RccStablesTopUp]: ContractRccStablesRegistry,
   [MotionType.PmlStablesTopUp]: ContractPmlStablesRegistry,
   [MotionType.AtcStablesTopUp]: ContractAtcStablesRegistry,
+  [MotionType.RccDAITopUp]: ContractRccStablesRegistry,
+  [MotionType.PmlDAITopUp]: ContractPmlStablesRegistry,
+  [MotionType.AtcDAITopUp]: ContractAtcStablesRegistry,
   [MotionType.GasFunderETHTopUp]: ContractGasFunderETHRegistry,
   [MotionType.AllowedRecipientTopUp]: ContractAllowedRecipientRegistry,
   [MotionType.AllowedRecipientTopUpReferralDai]:

--- a/modules/motions/hooks/usePeriodLimitsInfo.ts
+++ b/modules/motions/hooks/usePeriodLimitsInfo.ts
@@ -1,7 +1,7 @@
 import { LimitCheckerAbi, EasyTrackAbi } from 'generated'
 import { createContractHelpers } from 'modules/blockChain/utils/createContractHelpers'
 import {
-  ContractLegoDAIRegistry,
+  ContractLegoStablesRegistry,
   ContractEasyTrack,
   ContractAllowedRecipientRegistry,
   ContractAllowedRecipientReferralDaiRegistry,
@@ -102,7 +102,7 @@ const registryByMotionType: {
   [key in MotionType]?: ReturnType<typeof createContractHelpers>
 } = {
   [MotionType.LegoLDOTopUp]: ContractLegoLDORegistry,
-  [MotionType.LegoDAITopUp]: ContractLegoDAIRegistry,
+  [MotionType.LegoDAITopUp]: ContractLegoStablesRegistry,
   [MotionType.RccStablesTopUp]: ContractRccStablesRegistry,
   [MotionType.PmlStablesTopUp]: ContractPmlStablesRegistry,
   [MotionType.AtcStablesTopUp]: ContractAtcStablesRegistry,
@@ -116,6 +116,7 @@ const registryByMotionType: {
   [MotionType.AllowedRecipientTopUpTrpLdo]:
     ContractAllowedRecipientTrpLdoRegistry,
   [MotionType.StethRewardProgramTopUp]: ContractStethRewardProgramRegistry,
+  [MotionType.LegoStablesTopUp]: ContractLegoStablesRegistry,
 }
 
 export const usePeriodLimitsInfoByMotionType = (props: {

--- a/modules/motions/hooks/useRegistryWithLimits.ts
+++ b/modules/motions/hooks/useRegistryWithLimits.ts
@@ -15,6 +15,9 @@ import {
   ContractRewardsShareProgramRegistry,
   ContractRccStablesRegistry,
   ContractSandboxStablesAllowedRecipientRegistry,
+  ContractRccStethAllowedRecipientsRegistry,
+  ContractPmlStethAllowedRecipientsRegistry,
+  ContractAtcStethAllowedRecipientsRegistry,
 } from 'modules/blockChain/contracts'
 import { getEventsRecipientAdded } from 'modules/motions/utils'
 import { MotionType } from 'modules/motions/types'
@@ -62,6 +65,9 @@ export const REGISTRY_WITH_LIMITS_BY_MOTION_TYPE = {
     ContractSandboxStablesAllowedRecipientRegistry,
   [MotionType.SandboxStablesTopUp]:
     ContractSandboxStablesAllowedRecipientRegistry,
+  [MotionType.RccStethTopUp]: ContractRccStethAllowedRecipientsRegistry,
+  [MotionType.PmlStethTopUp]: ContractPmlStethAllowedRecipientsRegistry,
+  [MotionType.AtcStethTopUp]: ContractAtcStethAllowedRecipientsRegistry,
 } as const
 
 type HookArgs = {

--- a/modules/motions/hooks/useRegistryWithLimits.ts
+++ b/modules/motions/hooks/useRegistryWithLimits.ts
@@ -3,7 +3,7 @@ import { useSWR, SWRResponse } from 'modules/network/hooks/useSwr'
 import { useWeb3 } from 'modules/blockChain/hooks/useWeb3'
 import {
   ContractLegoLDORegistry,
-  ContractLegoDAIRegistry,
+  ContractLegoStablesRegistry,
   ContractPmlStablesRegistry,
   ContractAtcStablesRegistry,
   ContractGasFunderETHRegistry,
@@ -31,7 +31,7 @@ type AllowedRecipient = {
 
 export const REGISTRY_WITH_LIMITS_BY_MOTION_TYPE = {
   [MotionType.LegoLDOTopUp]: ContractLegoLDORegistry,
-  [MotionType.LegoDAITopUp]: ContractLegoDAIRegistry,
+  [MotionType.LegoDAITopUp]: ContractLegoStablesRegistry,
   [MotionType.RccDAITopUp]: ContractRccStablesRegistry,
   [MotionType.PmlDAITopUp]: ContractPmlStablesRegistry,
   [MotionType.AtcDAITopUp]: ContractAtcStablesRegistry,
@@ -68,6 +68,7 @@ export const REGISTRY_WITH_LIMITS_BY_MOTION_TYPE = {
   [MotionType.RccStethTopUp]: ContractRccStethAllowedRecipientsRegistry,
   [MotionType.PmlStethTopUp]: ContractPmlStethAllowedRecipientsRegistry,
   [MotionType.AtcStethTopUp]: ContractAtcStethAllowedRecipientsRegistry,
+  [MotionType.LegoStablesTopUp]: ContractLegoStablesRegistry,
 } as const
 
 type HookArgs = {

--- a/modules/motions/hooks/useTokenByTopUpType.ts
+++ b/modules/motions/hooks/useTokenByTopUpType.ts
@@ -58,6 +58,18 @@ const TOKEN = {
     label: 'stETH',
     value: (chainId: CHAINS) => CONTRACT_ADDRESSES.STETH[chainId],
   },
+  [MotionType.RccStethTopUp]: {
+    label: 'stETH',
+    value: (chainId: CHAINS) => CONTRACT_ADDRESSES.STETH[chainId],
+  },
+  [MotionType.PmlStethTopUp]: {
+    label: 'stETH',
+    value: (chainId: CHAINS) => CONTRACT_ADDRESSES.STETH[chainId],
+  },
+  [MotionType.AtcStethTopUp]: {
+    label: 'stETH',
+    value: (chainId: CHAINS) => CONTRACT_ADDRESSES.STETH[chainId],
+  },
 }
 
 const isTopUpType = (type: unknown): type is keyof typeof TOKEN => {

--- a/modules/motions/hooks/useTransitionLimits.ts
+++ b/modules/motions/hooks/useTransitionLimits.ts
@@ -13,21 +13,21 @@ import { connectERC20Contract } from '../utils/connectTokenContract'
 import { DEFAULT_DECIMALS } from 'modules/blockChain/constants'
 
 // Data structure reference
-// https://github.com/lidofinance/scripts/blob/2a30b9654abc90b20debf837f99cd02f248d6644/scripts/setup_easytrack_limits.py#L67-L100
-const LDO_INDEX = 1
-const ETH_INDEX = 4
-const DAI_INDEX = 7
-const STETH_INDEX = 10
-const USDC_INDEX = 13
-const USDT_INDEX = 16
+// https://github.com/lidofinance/scripts/blob/bda3568d1291bdc7ba422fb20150313f2d1778c3/scripts/vote_2024_01_16.py#L106
+const STETH_INDEX = 1
+const DAI_INDEX = 4
+const LDO_INDEX = 7
+const USDC_INDEX = 10
+const USDT_INDEX = 13
+const ETH_INDEX = 16
 
 const TOKEN_INDEXES = [
-  LDO_INDEX,
-  ETH_INDEX,
-  DAI_INDEX,
   STETH_INDEX,
+  DAI_INDEX,
+  LDO_INDEX,
   USDC_INDEX,
   USDT_INDEX,
+  ETH_INDEX,
 ]
 
 const decodeLimit = (val: BigNumber, decimals: number | null) => {

--- a/modules/motions/types.ts
+++ b/modules/motions/types.ts
@@ -40,6 +40,9 @@ export const MotionTypeForms = {
   RccDAITopUp: 'RccDAITopUp',
   PmlDAITopUp: 'PmlDAITopUp',
   AtcDAITopUp: 'AtcDAITopUp',
+  RccStethTopUp: 'RccStethTopUp',
+  PmlStethTopUp: 'PmlStethTopUp',
+  AtcStethTopUp: 'AtcStethTopUp',
 } as const
 // intentionally
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/motions/types.ts
+++ b/modules/motions/types.ts
@@ -39,6 +39,7 @@ export const MotionTypeForms = {
   RccStethTopUp: 'RccStethTopUp',
   PmlStethTopUp: 'PmlStethTopUp',
   AtcStethTopUp: 'AtcStethTopUp',
+  LegoStablesTopUp: 'LegoStablesTopUp',
 } as const
 // intentionally
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/motions/types.ts
+++ b/modules/motions/types.ts
@@ -9,7 +9,6 @@ export const MotionTypeForms = {
   // ET
   AllowedRecipientTopUpTrpLdo: 'AllowedRecipientTopUpTrpLdo',
   LegoLDOTopUp: 'LegoLDOTopUp',
-  LegoDAITopUp: 'LegoDAITopUp',
   RccStablesTopUp: 'RccStablesTopUp',
   PmlStablesTopUp: 'PmlStablesTopUp',
   AtcStablesTopUp: 'AtcStablesTopUp',
@@ -66,6 +65,7 @@ export const MotionTypeDisplayOnly = {
   RccDAITopUp: 'RccDAITopUp',
   PmlDAITopUp: 'PmlDAITopUp',
   AtcDAITopUp: 'AtcDAITopUp',
+  LegoDAITopUp: 'LegoDAITopUp',
 } as const
 // intentionally
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/motions/types.ts
+++ b/modules/motions/types.ts
@@ -37,9 +37,6 @@ export const MotionTypeForms = {
   SandboxStablesTopUp: 'SandboxStablesTopUp',
   SandboxStablesAdd: 'SandboxStablesAdd',
   SandboxStablesRemove: 'SandboxStablesRemove',
-  RccDAITopUp: 'RccDAITopUp',
-  PmlDAITopUp: 'PmlDAITopUp',
-  AtcDAITopUp: 'AtcDAITopUp',
   RccStethTopUp: 'RccStethTopUp',
   PmlStethTopUp: 'PmlStethTopUp',
   AtcStethTopUp: 'AtcStethTopUp',
@@ -66,6 +63,9 @@ export const MotionTypeDisplayOnly = {
   AllowedRecipientAddReferralDai: 'AllowedRecipientAddReferralDai',
   AllowedRecipientRemoveReferralDai: 'AllowedRecipientRemoveReferralDai',
   AllowedRecipientTopUpReferralDai: 'AllowedRecipientTopUpReferralDai',
+  RccDAITopUp: 'RccDAITopUp',
+  PmlDAITopUp: 'PmlDAITopUp',
+  AtcDAITopUp: 'AtcDAITopUp',
 } as const
 // intentionally
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/motions/ui/MotionDescription/MotionDescription.tsx
+++ b/modules/motions/ui/MotionDescription/MotionDescription.tsx
@@ -279,6 +279,12 @@ const MOTION_DESCRIPTIONS = {
   [MotionType.AtcStethTopUp]: (props: DescWithLimitsProps) => (
     <DescTopUpWithLimits {...props} registryType={MotionType.AtcStethTopUp} />
   ),
+  [MotionType.LegoStablesTopUp]: (props: GenericDescProps) => (
+    <DescTopUpWithLimitsAndCustomToken
+      {...props}
+      registryType={MotionType.LegoStablesTopUp}
+    />
+  ),
 } as const
 
 type Props = {

--- a/modules/motions/ui/MotionDescription/MotionDescription.tsx
+++ b/modules/motions/ui/MotionDescription/MotionDescription.tsx
@@ -270,6 +270,15 @@ const MOTION_DESCRIPTIONS = {
       registryType={MotionType.SandboxStablesTopUp}
     />
   ),
+  [MotionType.RccStethTopUp]: (props: DescWithLimitsProps) => (
+    <DescTopUpWithLimits {...props} registryType={MotionType.RccStethTopUp} />
+  ),
+  [MotionType.PmlStethTopUp]: (props: DescWithLimitsProps) => (
+    <DescTopUpWithLimits {...props} registryType={MotionType.PmlStethTopUp} />
+  ),
+  [MotionType.AtcStethTopUp]: (props: DescWithLimitsProps) => (
+    <DescTopUpWithLimits {...props} registryType={MotionType.AtcStethTopUp} />
+  ),
 } as const
 
 type Props = {

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
@@ -32,9 +32,6 @@ import {
   ContractEvmLegoLDOTopUp,
   ContractEvmLegoDAITopUp,
   ContractEvmGasFunderETHTopUp,
-  ContractEvmRccDAITopUp,
-  ContractEvmPmlDAITopUp,
-  ContractEvmAtcDAITopUp,
   ContractRccStethTopUp,
   ContractPmlStethTopUp,
   ContractAtcStethTopUp,
@@ -61,18 +58,6 @@ export const TOPUP_WITH_LIMITS_MAP = {
   [MotionType.GasFunderETHTopUp]: {
     evmContract: ContractEvmGasFunderETHTopUp,
     motionType: MotionType.GasFunderETHTopUp,
-  },
-  [MotionType.RccDAITopUp]: {
-    evmContract: ContractEvmRccDAITopUp,
-    motionType: MotionType.RccDAITopUp,
-  },
-  [MotionType.PmlDAITopUp]: {
-    evmContract: ContractEvmPmlDAITopUp,
-    motionType: MotionType.PmlDAITopUp,
-  },
-  [MotionType.AtcDAITopUp]: {
-    evmContract: ContractEvmAtcDAITopUp,
-    motionType: MotionType.AtcDAITopUp,
   },
   [MotionType.RccStethTopUp]: {
     evmContract: ContractRccStethTopUp,

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
@@ -30,7 +30,6 @@ import {
 
 import {
   ContractEvmLegoLDOTopUp,
-  ContractEvmLegoDAITopUp,
   ContractEvmGasFunderETHTopUp,
   ContractRccStethTopUp,
   ContractPmlStethTopUp,
@@ -50,10 +49,6 @@ export const TOPUP_WITH_LIMITS_MAP = {
   [MotionType.LegoLDOTopUp]: {
     evmContract: ContractEvmLegoLDOTopUp,
     motionType: MotionType.LegoLDOTopUp,
-  },
-  [MotionType.LegoDAITopUp]: {
-    evmContract: ContractEvmLegoDAITopUp,
-    motionType: MotionType.LegoDAITopUp,
   },
   [MotionType.GasFunderETHTopUp]: {
     evmContract: ContractEvmGasFunderETHTopUp,

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
@@ -35,6 +35,9 @@ import {
   ContractEvmRccDAITopUp,
   ContractEvmPmlDAITopUp,
   ContractEvmAtcDAITopUp,
+  ContractRccStethTopUp,
+  ContractPmlStethTopUp,
+  ContractAtcStethTopUp,
 } from 'modules/blockChain/contracts'
 import { MotionType } from 'modules/motions/types'
 import { createMotionFormPart } from './createMotionFormPart'
@@ -70,6 +73,18 @@ export const TOPUP_WITH_LIMITS_MAP = {
   [MotionType.AtcDAITopUp]: {
     evmContract: ContractEvmAtcDAITopUp,
     motionType: MotionType.AtcDAITopUp,
+  },
+  [MotionType.RccStethTopUp]: {
+    evmContract: ContractRccStethTopUp,
+    motionType: MotionType.RccStethTopUp,
+  },
+  [MotionType.PmlStethTopUp]: {
+    evmContract: ContractPmlStethTopUp,
+    motionType: MotionType.PmlStethTopUp,
+  },
+  [MotionType.AtcStethTopUp]: {
+    evmContract: ContractAtcStethTopUp,
+    motionType: MotionType.AtcStethTopUp,
   },
 }
 

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
@@ -29,6 +29,7 @@ import {
   ContractEvmPmlStablesTopUp,
   ContractEvmAtcStablesTopUp,
   ContractEvmSandboxStablesTopUp,
+  ContractLegoStablesTopUp,
 } from 'modules/blockChain/contracts'
 import { MotionType } from 'modules/motions/types'
 import { createMotionFormPart } from './createMotionFormPart'
@@ -60,6 +61,10 @@ export const TOPUP_WITH_LIMITS_MAP = {
   [MotionType.SandboxStablesTopUp]: {
     evmContract: ContractEvmSandboxStablesTopUp,
     motionType: MotionType.SandboxStablesTopUp,
+  },
+  [MotionType.LegoStablesTopUp]: {
+    evmContract: ContractLegoStablesTopUp,
+    motionType: MotionType.LegoStablesTopUp,
   },
 }
 

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
@@ -115,7 +115,7 @@ export const formParts = ({
         allowedTokens,
         tokensDecimalsMap,
         initialLoading: isTokensDataLoading,
-      } = useAllowedTokens(registryType)
+      } = useAllowedTokens()
       const {
         data: periodLimitsData,
         initialLoading: isPeriodLimitsDataLoading,

--- a/modules/motions/ui/MotionFormStartNew/Parts/index.ts
+++ b/modules/motions/ui/MotionFormStartNew/Parts/index.ts
@@ -111,6 +111,15 @@ export const formParts = {
   [MotionTypeForms.PmlDAITopUp]: StartNewTopUpWithLimits.formParts({
     registryType: MotionTypeForms.PmlDAITopUp,
   }),
+  [MotionTypeForms.RccStethTopUp]: StartNewTopUpWithLimits.formParts({
+    registryType: MotionTypeForms.RccStethTopUp,
+  }),
+  [MotionTypeForms.PmlStethTopUp]: StartNewTopUpWithLimits.formParts({
+    registryType: MotionTypeForms.PmlStethTopUp,
+  }),
+  [MotionTypeForms.AtcStethTopUp]: StartNewTopUpWithLimits.formParts({
+    registryType: MotionTypeForms.AtcStethTopUp,
+  }),
 } as const
 
 export type FormData = {

--- a/modules/motions/ui/MotionFormStartNew/Parts/index.ts
+++ b/modules/motions/ui/MotionFormStartNew/Parts/index.ts
@@ -27,9 +27,6 @@ export const formParts = {
   [MotionTypeForms.LegoLDOTopUp]: StartNewTopUpWithLimits.formParts({
     registryType: MotionTypeForms.LegoLDOTopUp,
   }),
-  [MotionTypeForms.LegoDAITopUp]: StartNewTopUpWithLimits.formParts({
-    registryType: MotionTypeForms.LegoDAITopUp,
-  }),
   [MotionTypeForms.RccStablesTopUp]:
     StartNewTopUpWithLimitsAndCustomToken.formParts({
       registryType: MotionTypeForms.RccStablesTopUp,

--- a/modules/motions/ui/MotionFormStartNew/Parts/index.ts
+++ b/modules/motions/ui/MotionFormStartNew/Parts/index.ts
@@ -102,15 +102,6 @@ export const formParts = {
     StartNewTopUpWithLimitsAndCustomToken.formParts({
       registryType: MotionTypeForms.SandboxStablesTopUp,
     }),
-  [MotionTypeForms.RccDAITopUp]: StartNewTopUpWithLimits.formParts({
-    registryType: MotionTypeForms.RccDAITopUp,
-  }),
-  [MotionTypeForms.AtcDAITopUp]: StartNewTopUpWithLimits.formParts({
-    registryType: MotionTypeForms.AtcDAITopUp,
-  }),
-  [MotionTypeForms.PmlDAITopUp]: StartNewTopUpWithLimits.formParts({
-    registryType: MotionTypeForms.PmlDAITopUp,
-  }),
   [MotionTypeForms.RccStethTopUp]: StartNewTopUpWithLimits.formParts({
     registryType: MotionTypeForms.RccStethTopUp,
   }),

--- a/modules/motions/ui/MotionFormStartNew/Parts/index.ts
+++ b/modules/motions/ui/MotionFormStartNew/Parts/index.ts
@@ -108,6 +108,10 @@ export const formParts = {
   [MotionTypeForms.AtcStethTopUp]: StartNewTopUpWithLimits.formParts({
     registryType: MotionTypeForms.AtcStethTopUp,
   }),
+  [MotionTypeForms.LegoStablesTopUp]:
+    StartNewTopUpWithLimitsAndCustomToken.formParts({
+      registryType: MotionTypeForms.LegoStablesTopUp,
+    }),
 } as const
 
 export type FormData = {

--- a/modules/motions/utils/getMotionTypeDisplayName.ts
+++ b/modules/motions/utils/getMotionTypeDisplayName.ts
@@ -10,9 +10,9 @@ export const MotionTypeDisplayNames: Record<
   [MotionType.AllowedRecipientTopUpTrpLdo]: 'Top up LDO TRP',
   [MotionType.LegoLDOTopUp]: 'Top up LEGO LDO',
   [MotionType.LegoDAITopUp]: 'Top up LEGO DAI',
-  [MotionType.RccStablesTopUp]: 'Top up RCC',
-  [MotionType.PmlStablesTopUp]: 'Top up PML',
-  [MotionType.AtcStablesTopUp]: 'Top up ATC',
+  [MotionType.RccStablesTopUp]: 'Top up RCC stablecoins',
+  [MotionType.PmlStablesTopUp]: 'Top up PML stablecoins',
+  [MotionType.AtcStablesTopUp]: 'Top up ATC stablecoins',
   [MotionType.StethRewardProgramAdd]: 'Add stETH reward program',
   [MotionType.StethRewardProgramRemove]: 'Remove stETH reward program',
   [MotionType.StethRewardProgramTopUp]: 'Top up stETH reward programs',
@@ -37,6 +37,9 @@ export const MotionTypeDisplayNames: Record<
   [MotionType.SDVTNodeOperatorManagerChange]: 'Change node operators managers',
   [MotionType.SandboxNodeOperatorIncreaseLimit]:
     '[NOR SandBox] Increase node operator staking limit',
+  [MotionType.RccStethTopUp]: 'Top up RCC stETH',
+  [MotionType.PmlStethTopUp]: 'Top up PML stETH',
+  [MotionType.AtcStethTopUp]: 'Top up ATC stETH',
 
   [EvmUnrecognized]: 'Unrecognized evm factory',
 

--- a/modules/motions/utils/getMotionTypeDisplayName.ts
+++ b/modules/motions/utils/getMotionTypeDisplayName.ts
@@ -39,6 +39,7 @@ export const MotionTypeDisplayNames: Record<
   [MotionType.RccStethTopUp]: 'Top up RCC stETH',
   [MotionType.PmlStethTopUp]: 'Top up PML stETH',
   [MotionType.AtcStethTopUp]: 'Top up ATC stETH',
+  [MotionType.LegoStablesTopUp]: 'Top up LEGO stablecoins',
 
   [EvmUnrecognized]: 'Unrecognized evm factory',
 

--- a/modules/motions/utils/getMotionTypeDisplayName.ts
+++ b/modules/motions/utils/getMotionTypeDisplayName.ts
@@ -9,7 +9,6 @@ export const MotionTypeDisplayNames: Record<
     'Increase node operator staking limit',
   [MotionType.AllowedRecipientTopUpTrpLdo]: 'Top up LDO TRP',
   [MotionType.LegoLDOTopUp]: 'Top up LEGO LDO',
-  [MotionType.LegoDAITopUp]: 'Top up LEGO DAI',
   [MotionType.RccStablesTopUp]: 'Top up RCC stablecoins',
   [MotionType.PmlStablesTopUp]: 'Top up PML stablecoins',
   [MotionType.AtcStablesTopUp]: 'Top up ATC stablecoins',
@@ -65,6 +64,7 @@ export const MotionTypeDisplayNames: Record<
   [MotionType.SandboxStablesTopUp]: 'Top up sandbox stables',
   [MotionType.SandboxStablesAdd]: 'Add sandbox stables recipient',
   [MotionType.SandboxStablesRemove]: 'Remove sandbox stables recipient',
+  [MotionType.LegoDAITopUp]: 'Top up LEGO DAI',
 } as const
 
 export function getMotionTypeDisplayName(


### PR DESCRIPTION
<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

According to the upcoming Jan 23 [Omnibus](https://www.notion.so/Checklist-omnibus-23-01-2024-171-be9acb321e194688bcbc9bfcb090f015) changelog, we need to add the support of new top up factories and remove factories that were proposed to be removed.

### Changelog

- Added stETH Top Up EVM script factories for RCC, PML and ATC on Mainnet and Holesky Testnet;
- Removed DAI Top Up EVM script factories for RCC, PML and ATC;
- Added Stables Top Up EVM script factories for RCC, PML and ATC on Mainnet and Holesky Testnet.
- Removed DAI Top Up EVM script factory for LEGO;
- Added Stables Top Up EVM script factory for LEGO on Mainnet and Holesky Testnet.

New addresses are already available in the [Docs](https://docs.lido.fi/deployed-contracts/)

### Testing notes:

**Do not merge until the next omnibus is enacted!** 

### Checklist:

- [x] Checked the changes locally.
