### PR TITLE
feat: rcc/pml/atc top up factories

### DIFF
--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -78,16 +78,19 @@ export const LegoStablesRegistry: ChainAddressMap = {
 export const RccStablesRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xDc1A0C7849150f466F07d48b38eAA6cE99079f80',
   [CHAINS.Goerli]: '0x1440E8aDbE3a42a9EDB4b30059df8F6c35205a15',
+  [CHAINS.Holesky]: '0x17Ab17290bcDbea381500525A58e16e29093523c',
 }
 
 export const PmlStablesRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xDFfCD3BF14796a62a804c1B16F877Cf7120379dB',
   [CHAINS.Goerli]: '0xAadfBd1ADE92d85c967f4aE096141F0F802F46Db',
+  [CHAINS.Holesky]: '0x580B23a97F827F2b6E51B3DEc270Ef522Ccf520c',
 }
 
 export const AtcStablesRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xe07305F43B11F230EaA951002F6a55a16419B707',
   [CHAINS.Goerli]: '0xedD3B813275e1A88c2283FAfa5bf5396938ef59e',
+  [CHAINS.Holesky]: '0x37675423796D39C19351c5C322C3692b23a3d9bd',
 }
 
 export const gasFunderETHRegistry: ChainAddressMap = {

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -217,6 +217,9 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.PmlStethTopUp]: '0x8612A51e4914FfFb25D96d1A310D4C6342c2091E',
     [MotionType.AtcStethTopUp]: '0x1395970895282333dC914172944f52F15Df63620',
     [MotionType.LegoStablesTopUp]: '0x7Bb5C5965a63aFb6a05D19bB03e3f170E2d7d684',
+    [MotionType.RccStablesTopUp]: '0xD497E7e039FeFBc64dBB7b75368afb06D07Bc73F',
+    [MotionType.PmlStablesTopUp]: '0x5BAE56ECfB616eAbbDB048AC930FA1Db82f18900',
+    [MotionType.AtcStablesTopUp]: '0xfa54cf78474cD4A7f4408Dd0efA36e44b6269813',
 
     // next motion factories are @deprecated
     // we are keeping them here to display history data

--- a/modules/motions/hooks/useTransitionLimits.ts
+++ b/modules/motions/hooks/useTransitionLimits.ts
@@ -13,21 +13,21 @@ import { connectERC20Contract } from '../utils/connectTokenContract'
 import { DEFAULT_DECIMALS } from 'modules/blockChain/constants'
 
 // Data structure reference
-// https://github.com/lidofinance/scripts/blob/2a30b9654abc90b20debf837f99cd02f248d6644/scripts/setup_easytrack_limits.py#L67-L100
-const LDO_INDEX = 1
-const ETH_INDEX = 4
-const DAI_INDEX = 7
-const STETH_INDEX = 10
-const USDC_INDEX = 13
-const USDT_INDEX = 16
+// https://github.com/lidofinance/scripts/blob/bda3568d1291bdc7ba422fb20150313f2d1778c3/scripts/vote_2024_01_16.py#L106
+const STETH_INDEX = 1
+const DAI_INDEX = 4
+const LDO_INDEX = 7
+const USDC_INDEX = 10
+const USDT_INDEX = 13
+const ETH_INDEX = 16
 
 const TOKEN_INDEXES = [
-  LDO_INDEX,
-  ETH_INDEX,
-  DAI_INDEX,
   STETH_INDEX,
+  DAI_INDEX,
+  LDO_INDEX,
   USDC_INDEX,
   USDT_INDEX,
+  ETH_INDEX,
 ]
 
 const decodeLimit = (val: BigNumber, decimals: number | null) => {


### PR DESCRIPTION


### Description

- Added new top-up stables factories for RCC, PML, and ATC. Addresses to check are available via [the docs](https://docs.lido.fi/deployed-contracts/holesky/#easy-track-factories-for-token-transfers);
- Transition limits updated according to the upcoming [voting script](https://github.com/lidofinance/scripts/blob/bda3568d1291bdc7ba422fb20150313f2d1778c3/scripts/vote_2024_01_16.py#L106)

### Checklist:

- [x] Checked the changes locally.
