### PR TITLE
feat: fetch active motions from subgraph by id

### DIFF
--- a/modules/motions/network/motionsSubgraphFetchers.ts
+++ b/modules/motions/network/motionsSubgraphFetchers.ts
@@ -16,9 +16,11 @@ export const getQuerySubgraphMotions = (
     ${arg.first !== undefined ? `first: ${arg.first}` : ''}
     orderBy: startDate
     orderDirection: desc
-    where: { status_in: ["CANCELED", "REJECTED", "ENACTED"]${
-      arg.id ? `, id: ${arg.id}` : ''
-    } }
+    where: ${
+      arg.id
+        ? `{ id: ${arg.id} }`
+        : `{ status_in: ["CANCELED", "REJECTED", "ENACTED"] }`
+    }
   ) {
     id
     evmScriptFactory


### PR DESCRIPTION
### Description

This PR adds the ability to fetch any motion by its id from the Subgraph without requirements on status. 

### Checklist:

- [x] Checked the changes locally.
