### PR TITLE
fix: add missing abi to decoder

### DIFF
--- a/modules/motions/hooks/useEVMScriptDecoder.ts
+++ b/modules/motions/hooks/useEVMScriptDecoder.ts
@@ -47,6 +47,12 @@ export function useEVMScriptDecoder() {
         [KEYS.AragonACL]: abis.AragonACLAbi__factory.abi,
         [KEYS.SDVTRegistry]: abis.SDVTRegistryAbi__factory.abi,
         [KEYS.SandboxNodeOperatorsRegistry]: abis.NodeOperatorsAbi__factory.abi,
+        [KEYS.RccStethAllowedRecipientsRegistry]:
+          abis.RegistryWithLimitsAbi__factory.abi,
+        [KEYS.PmlStethAllowedRecipientsRegistry]:
+          abis.RegistryWithLimitsAbi__factory.abi,
+        [KEYS.AtcStethAllowedRecipientsRegistry]:
+          abis.RegistryWithLimitsAbi__factory.abi,
       }),
     )
   }, `evm-script-decoder-${chainId}`)


### PR DESCRIPTION
Add missing ABIs to `useEVMScriptDecoder`