### PR TITLE
fix: Simple DVT archived motions descriptions

### DIFF
--- a/modules/motions/types.ts
+++ b/modules/motions/types.ts
@@ -120,6 +120,7 @@ export type Motion = {
   enacted_at?: number
   canceled_at?: number
   rejected_at?: number
+  isOnChain: boolean
 }
 
 export type RawMotionOnchain = PromiseValue<

--- a/modules/motions/ui/MotionDescription/DescSDVTNodeOperatorNamesSet.tsx
+++ b/modules/motions/ui/MotionDescription/DescSDVTNodeOperatorNamesSet.tsx
@@ -5,6 +5,7 @@ import { useSDVTNodeOperatorsList } from 'modules/motions/hooks/useSDVTNodeOpera
 // SetNodeOperatorNames
 export function DescSDVTNodeOperatorNamesSet({
   callData,
+  isOnChain,
 }: NestProps<SetNodeOperatorNamesAbi['decodeEVMScriptCallData']>) {
   const { data: nodeOperatorsList } = useSDVTNodeOperatorsList()
   return (
@@ -14,8 +15,9 @@ export function DescSDVTNodeOperatorNamesSet({
         const nodeOperator = nodeOperatorsList?.[nodeOperatorId]
         return (
           <div key={nodeOperatorId}>
-            Change Node Operator <b>{nodeOperator ? nodeOperator.name : ''}</b>{' '}
-            (id: {nodeOperatorId}) name to <b>{item.name}</b>
+            Change Node Operator{' '}
+            <b>{nodeOperator && isOnChain ? nodeOperator.name : ''}</b> (id:{' '}
+            {nodeOperatorId}) name to <b>{item.name}</b>
             {index === callData.length - 1 ? '.' : '; '}
           </div>
         )

--- a/modules/motions/ui/MotionDescription/DescSDVTNodeOperatorRewardAddressesSet.tsx
+++ b/modules/motions/ui/MotionDescription/DescSDVTNodeOperatorRewardAddressesSet.tsx
@@ -6,6 +6,7 @@ import { AddressInlineWithPop } from 'modules/shared/ui/Common/AddressInlineWith
 // SetNodeOperatorRewardAddresses
 export function DescSDVTNodeOperatorRewardAddressesSet({
   callData,
+  isOnChain,
 }: NestProps<SetNodeOperatorRewardAddressesAbi['decodeEVMScriptCallData']>) {
   const { data: nodeOperatorsList } = useSDVTNodeOperatorsList()
   return (
@@ -18,7 +19,7 @@ export function DescSDVTNodeOperatorRewardAddressesSet({
             Change reward address of Node Operator{' '}
             <b>{nodeOperator ? nodeOperator.name : ''}</b> (id: {nodeOperatorId}
             )
-            {nodeOperator?.rewardAddress ? (
+            {nodeOperator?.rewardAddress && isOnChain ? (
               <>
                 {' '}
                 from{' '}

--- a/modules/motions/ui/MotionDescription/DescSDVTTargetValidatorLimitsUpdate.tsx
+++ b/modules/motions/ui/MotionDescription/DescSDVTTargetValidatorLimitsUpdate.tsx
@@ -5,6 +5,7 @@ import { useSDVTNodeOperatorsList } from 'modules/motions/hooks/useSDVTNodeOpera
 // UpdateTargetValidatorLimits
 export function DescSDVTTargetValidatorLimitsUpdate({
   callData,
+  isOnChain,
 }: NestProps<UpdateTargetValidatorLimitsAbi['decodeEVMScriptCallData']>) {
   const { data: nodeOperatorsList } = useSDVTNodeOperatorsList({
     withSummary: true,
@@ -22,6 +23,7 @@ export function DescSDVTTargetValidatorLimitsUpdate({
             <div key={nodeOperatorId}>
               Disable target validator limit for Node Operator{' '}
               <b>{nodeOperatorName}</b> (id: {nodeOperatorId})
+              {index === callData.length - 1 ? '.' : '; '}
             </div>
           )
         }
@@ -30,7 +32,10 @@ export function DescSDVTTargetValidatorLimitsUpdate({
           <div key={nodeOperatorId}>
             Set target validator limit for Node Operator{' '}
             <b>{nodeOperatorName}</b> (id: {nodeOperatorId}){' '}
-            {`from ${nodeOperator?.targetValidatorsCount} to ${item.targetLimit}`}
+            {nodeOperator && isOnChain
+              ? `from ${nodeOperator.targetValidatorsCount} `
+              : ''}
+            {`to ${item.targetLimit}`}
             {index === callData.length - 1 ? '.' : '; '}
           </div>
         )

--- a/modules/motions/ui/MotionDescription/DescSDVTVettedValidatorsLimitsSet.tsx
+++ b/modules/motions/ui/MotionDescription/DescSDVTVettedValidatorsLimitsSet.tsx
@@ -5,6 +5,7 @@ import { useSDVTNodeOperatorsList } from 'modules/motions/hooks/useSDVTNodeOpera
 // SetVettedValidatorsLimits
 export function DescSDVTVettedValidatorsLimitsSet({
   callData,
+  isOnChain,
 }: NestProps<SetVettedValidatorsLimitsAbi['decodeEVMScriptCallData']>) {
   const { data: nodeOperatorsList } = useSDVTNodeOperatorsList({
     withSummary: true,
@@ -18,7 +19,10 @@ export function DescSDVTVettedValidatorsLimitsSet({
           <div key={nodeOperatorId}>
             Set Node Operator <b>{nodeOperator ? nodeOperator.name : ''}</b>{' '}
             (id: {nodeOperatorId}) vetted validators limit{' '}
-            {`from ${nodeOperator?.totalVettedValidators} to ${item.stakingLimit}`}
+            {nodeOperator && isOnChain
+              ? `from ${nodeOperator.totalVettedValidators} `
+              : ''}
+            {`to ${item.stakingLimit}`}
           </div>
         )
       })}

--- a/modules/motions/ui/MotionDescription/MotionDescription.tsx
+++ b/modules/motions/ui/MotionDescription/MotionDescription.tsx
@@ -59,6 +59,7 @@ type DescNodeOperatorIncreaseLimitProps = NestProps<
 >
 
 type GenericDescProps = {
+  isOnChain?: boolean
   callData: any
 }
 
@@ -325,7 +326,7 @@ export function MotionDescription({ motion }: Props) {
 
   return (
     <DescWrap>
-      <Desc callData={callData} />
+      <Desc callData={callData} isOnChain={motion.isOnChain} />
     </DescWrap>
   )
 }

--- a/modules/motions/ui/MotionDescription/types.ts
+++ b/modules/motions/ui/MotionDescription/types.ts
@@ -2,4 +2,5 @@ import { UnpackedPromise } from 'modules/shared/utils/utilTypes'
 
 export type NestProps<C extends (...a: any) => Promise<any>> = {
   callData: UnpackedPromise<ReturnType<C>>
+  isOnChain?: boolean
 }

--- a/modules/motions/utils/formatMotionDataOnchain.ts
+++ b/modules/motions/utils/formatMotionDataOnchain.ts
@@ -26,6 +26,7 @@ export function formatMotionDataOnchain(rawMotion: RawMotionOnchain): Motion {
     objectionsThreshold: Number(rawMotion.objectionsThreshold),
     objectionsAmount: rawMotion.objectionsAmount,
     evmScriptHash: rawMotion.evmScriptHash,
+    isOnChain: true,
   }
 
   return {

--- a/modules/motions/utils/formatMotionDataSubgraph.ts
+++ b/modules/motions/utils/formatMotionDataSubgraph.ts
@@ -17,5 +17,6 @@ export function formatMotionDataSubgraph(rawMotion: RawMotionSubgraph): Motion {
     rejected_at: rawMotion.rejected_at
       ? Number(rawMotion.rejected_at)
       : undefined,
+    isOnChain: false,
   }
 }


### PR DESCRIPTION

### Description

Remove on-chain node operators data from archived motions' descriptions 

### Checklist:

- [x] Checked the changes locally.
