### PR TITLE
fix: add custom decimals value validation

### DIFF
--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
@@ -139,6 +139,7 @@ export const formParts = ({
       const { watch, setValue, trigger } = useFormContext()
       const selectedPrograms: Program[] = watch(fieldNames.programs)
       const selectedTokenAddress: string = watch(fieldNames.tokenAddress)
+      const selectedTokenDecimals: number = watch(fieldNames.tokenDecimals)
 
       const selectedTokenLabel = useMemo(() => {
         if (!selectedTokenAddress || !allowedTokens?.length) {
@@ -295,7 +296,10 @@ export const formParts = ({
                     rules={{
                       required: 'Field is required',
                       validate: value => {
-                        const tokenError = validateToken(value)
+                        const tokenError = validateToken(
+                          value,
+                          selectedTokenDecimals,
+                        )
                         if (tokenError) {
                           return tokenError
                         }

--- a/modules/tokens/utils/validateToken.ts
+++ b/modules/tokens/utils/validateToken.ts
@@ -1,13 +1,14 @@
 import { utils } from 'ethers'
+import { DEFAULT_DECIMALS } from 'modules/blockChain/constants'
 
-export const validateToken = (value: string) => {
+export const validateToken = (value: string, decimals = DEFAULT_DECIMALS) => {
   if (Number(value) <= 0) {
-    return 'Must be positive'
+    return 'Value must be positive'
   }
   try {
-    utils.parseEther(value)
+    utils.parseUnits(value, decimals)
     return null
   } catch (_) {
-    return 'Unable to parse'
+    return 'Unable to parse value'
   }
 }


### PR DESCRIPTION
When using an input to enter an asset amount with a `decimals` value other than 18, an error may occur that blocks form submission.

This PR allows you to validate values for assets with any `decimals` value.