### PR TITLE
Feat/sdvt target limit factory v2

### DIFF
--- a/abi/dvt/SDVTRegistry.abi.json
+++ b/abi/dvt/SDVTRegistry.abi.json
@@ -12,6 +12,19 @@
     "constant": false,
     "inputs": [
       { "name": "_nodeOperatorId", "type": "uint256" },
+      { "name": "_targetLimitMode", "type": "uint256" },
+      { "name": "_targetLimit", "type": "uint256" }
+    ],
+    "name": "updateTargetValidatorsLimits",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_nodeOperatorId", "type": "uint256" },
       { "name": "_keysCount", "type": "uint256" },
       { "name": "_publicKeys", "type": "bytes" },
       { "name": "_signatures", "type": "bytes" }
@@ -169,6 +182,15 @@
     "type": "function"
   },
   {
+    "constant": false,
+    "inputs": [],
+    "name": "finalizeUpgrade_v3",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "constant": true,
     "inputs": [],
     "name": "getStuckPenaltyDelay",
@@ -187,6 +209,15 @@
     "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getRewardDistributionState",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -310,12 +341,12 @@
     "type": "function"
   },
   {
-    "constant": true,
+    "constant": false,
     "inputs": [{ "name": "", "type": "uint256" }],
     "name": "onRewardsMinted",
     "outputs": [],
     "payable": false,
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -325,6 +356,15 @@
     "outputs": [{ "name": "", "type": "bytes32" }],
     "payable": false,
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "distributeReward",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -509,7 +549,7 @@
     "inputs": [{ "name": "_nodeOperatorId", "type": "uint256" }],
     "name": "getNodeOperatorSummary",
     "outputs": [
-      { "name": "isTargetLimitActive", "type": "bool" },
+      { "name": "targetLimitMode", "type": "uint256" },
       { "name": "targetValidatorsCount", "type": "uint256" },
       { "name": "stuckValidatorsCount", "type": "uint256" },
       { "name": "refundedValidatorsCount", "type": "uint256" },
@@ -545,6 +585,18 @@
     "outputs": [{ "name": "", "type": "uint256" }],
     "payable": false,
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_nodeOperatorIds", "type": "bytes" },
+      { "name": "_vettedSigningKeysCounts", "type": "bytes" }
+    ],
+    "name": "decreaseVettedSigningKeysCount",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -765,6 +817,12 @@
   },
   {
     "anonymous": false,
+    "inputs": [{ "indexed": false, "name": "state", "type": "uint8" }],
+    "name": "RewardDistributionStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
     "inputs": [
       { "indexed": false, "name": "locatorAddress", "type": "address" }
     ],
@@ -848,7 +906,8 @@
     "anonymous": false,
     "inputs": [
       { "indexed": true, "name": "nodeOperatorId", "type": "uint256" },
-      { "indexed": false, "name": "targetValidatorsCount", "type": "uint256" }
+      { "indexed": false, "name": "targetValidatorsCount", "type": "uint256" },
+      { "indexed": false, "name": "targetLimitMode", "type": "uint256" }
     ],
     "name": "TargetValidatorsCountChanged",
     "type": "event"

--- a/abi/dvt/UpdateTargetValidatorLimits.abi.json
+++ b/abi/dvt/UpdateTargetValidatorLimits.abi.json
@@ -39,9 +39,9 @@
             "type": "uint256"
           },
           {
-            "internalType": "bool",
-            "name": "isTargetLimitActive",
-            "type": "bool"
+            "internalType": "uint256",
+            "name": "targetLimitMode",
+            "type": "uint256"
           },
           {
             "internalType": "uint256",

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -216,7 +216,7 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.SDVTVettedValidatorsLimitsSet]:
       '0x30Cb36DBb0596aD9Cf5159BD2c4B1456c18e47E8',
     [MotionType.SDVTTargetValidatorLimitsUpdate]:
-      '0xC91a676A69Eb49be9ECa1954fE6fc861AE07A9A2',
+      '0x431a156BEba95803a95452441C1959c4479710e1',
     [MotionType.SDVTNodeOperatorRewardAddressesSet]:
       '0x6Bfc576018C7f3D2a9180974E5c8e6CFa021f617',
     [MotionType.SDVTNodeOperatorNamesSet]:

--- a/modules/motions/ui/MotionDescription/DescSDVTTargetValidatorLimitsUpdate.tsx
+++ b/modules/motions/ui/MotionDescription/DescSDVTTargetValidatorLimitsUpdate.tsx
@@ -15,10 +15,15 @@ export function DescSDVTTargetValidatorLimitsUpdate({
       {callData.map((item, index) => {
         const nodeOperatorId = item.nodeOperatorId.toNumber()
         const nodeOperator = nodeOperatorsList?.[nodeOperatorId]
+        const targetLimitMode = item.targetLimitMode.toNumber()
+
+        let targetLimitModeDesc = 'disabled'
+        if (targetLimitMode == 1) targetLimitModeDesc = 'soft'
+        if (targetLimitMode == 2) targetLimitModeDesc = 'boosted exits'
 
         const nodeOperatorName = nodeOperator ? nodeOperator.name : ''
 
-        if (!item.isTargetLimitActive) {
+        if (targetLimitMode == 0) {
           return (
             <div key={nodeOperatorId}>
               Disable target validator limit for Node Operator{' '}
@@ -35,7 +40,7 @@ export function DescSDVTTargetValidatorLimitsUpdate({
             {nodeOperator && isOnChain
               ? `from ${nodeOperator.targetValidatorsCount} `
               : ''}
-            {`to ${item.targetLimit}`}
+            {`to ${item.targetLimit} in ${targetLimitModeDesc} mode`}
             {index === callData.length - 1 ? '.' : '; '}
           </div>
         )

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewSDVTTargetValidatorLimitsUpdate.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewSDVTTargetValidatorLimitsUpdate.tsx
@@ -20,14 +20,14 @@ import { MotionType } from 'modules/motions/types'
 import { createMotionFormPart } from './createMotionFormPart'
 import { estimateGasFallback } from 'modules/motions/utils'
 import { useSDVTNodeOperatorsList } from 'modules/motions/hooks/useSDVTNodeOperatorsList'
-import { CheckboxControl } from 'modules/shared/ui/Controls/Checkbox'
 import { validateUintValue } from 'modules/motions/utils/validateUintValue'
 import { NodeOperatorSelectControl } from 'modules/motions/ui/NodeOperatorSelectControl'
 import { InputNumberControl } from 'modules/shared/ui/Controls/InputNumber'
+import { SelectControl, Option } from 'modules/shared/ui/Controls/Select'
 
 type NodeOperator = {
   id: number | undefined
-  isTargetLimitActive: boolean
+  targetLimitMode: string
   targetLimit: string
 }
 
@@ -42,12 +42,12 @@ export const formParts = createMotionFormPart({
 
     const encodedCallData = new utils.AbiCoder().encode(
       [
-        'tuple(uint256 nodeOperatorId, bool isTargetLimitActive, uint256 targetLimit)[]',
+        'tuple(uint256 nodeOperatorId, uint256 targetLimitMode, uint256 targetLimit)[]',
       ],
       [
         sortedNodeOperators.map(nodeOperator => ({
           nodeOperatorId: Number(nodeOperator.id),
-          isTargetLimitActive: nodeOperator.isTargetLimitActive,
+          targetLimitMode: Number(nodeOperator.targetLimitMode),
           targetLimit: Number(nodeOperator.targetLimit),
         })),
       ],
@@ -66,7 +66,7 @@ export const formParts = createMotionFormPart({
     nodeOperators: [
       {
         id: undefined,
-        isTargetLimitActive: false,
+        targetLimitMode: '',
         targetLimit: '',
       },
     ] as NodeOperator[],
@@ -104,7 +104,7 @@ export const formParts = createMotionFormPart({
     const handleAddUpdate = () =>
       fieldsArr.append({
         id: undefined,
-        isTargetLimitActive: false,
+        targetLimitMode: '',
         targetLimit: '',
       } as NodeOperator)
 
@@ -154,18 +154,28 @@ export const formParts = createMotionFormPart({
                       const nodeOperator = nodeOperatorsList[Number(value)]
 
                       setValue(
-                        `${fieldNames.nodeOperators}.${fieldIndex}.isTargetLimitActive`,
-                        Boolean(nodeOperator.isTargetLimitActive),
+                        `${fieldNames.nodeOperators}.${fieldIndex}.targetLimitMode`,
+                        Number(nodeOperator.targetLimitMode),
                       )
                     }}
                   />
                 </Fieldset>
 
                 <Fieldset>
-                  <CheckboxControl
-                    label="Target validator limit active"
-                    name={`${fieldNames.nodeOperators}.${fieldIndex}.isTargetLimitActive`}
-                  />
+                  <SelectControl
+                    name={`${fieldNames.nodeOperators}.${fieldIndex}.targetLimitMode`}
+                    label="Target validator limit mode"
+                  >
+                    <Option key={0} value={0}>
+                      Disabled
+                    </Option>
+                    <Option key={1} value={1}>
+                      Soft limit
+                    </Option>
+                    <Option key={2} value={2}>
+                      Boosted exits
+                    </Option>
+                  </SelectControl>
                 </Fieldset>
 
                 <Fieldset>
@@ -183,7 +193,9 @@ export const formParts = createMotionFormPart({
                       )
                     }
                     disabled={
-                      !selectedNodeOperators[fieldIndex]?.isTargetLimitActive
+                      Number(
+                        selectedNodeOperators[fieldIndex]?.targetLimitMode,
+                      ) == 0
                     }
                     rules={{
                       required: 'Field is required',


### PR DESCRIPTION

### Description

Update SDVT factory `UpdateTargetValidatorLimits`. The new version introduces `targetLimitMode` field to the operator which can be updated via updated motion. The `targetLimitMode` can be 0 - 'disabled', 1 - 'soft', 2 - 'boosted exits' 

Initial PR - https://github.com/lidofinance/easy-track-ui/pull/267

### Notes

Keep in mind that since the factory will be updated only for the Holesky testnet, any release on prod will break the process of this motion creation. We can release on the testnet now, but we shouldn't release anything on prod until the backward capability fix is merged to the develop branch.

I will handle it and prepare an update in the coming days.