### PR TITLE
feat: add top up factories for Ecosystem Ops and Labs Ops (stETH and stables)

### DIFF
--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -209,3 +209,19 @@ export const AllianceOpsAllowedRecipientsRegistry: ChainAddressMap = {
   [CHAINS.Mainnet]: '0x3b525f4c059f246ca4aa995d21087204f30c9e2f',
   [CHAINS.Holesky]: '0xe1ba8dee84a4df8e99e495419365d979cdb19991',
 }
+
+export const EcosystemOpsStablesAllowedRecipientsRegistry: ChainAddressMap = {
+  [CHAINS.Holesky]: '0x0214CEBDEc06dc2729382860603d01113F068388',
+}
+
+export const EcosystemOpsStethAllowedRecipientsRegistry: ChainAddressMap = {
+  [CHAINS.Holesky]: '0x193d0bA65cf3a2726e12c5568c068D1B3ea51740',
+}
+
+export const LabsOpsStablesAllowedRecipientsRegistry: ChainAddressMap = {
+  [CHAINS.Holesky]: '0x303F5b60e3cf6Ea11d8509A1546401e311A13B92',
+}
+
+export const LabsOpsStethAllowedRecipientsRegistry: ChainAddressMap = {
+  [CHAINS.Holesky]: '0x02CD05c1cBa16113680648a8B3496A5aE312a935',
+}

--- a/modules/blockChain/contracts.ts
+++ b/modules/blockChain/contracts.ts
@@ -479,3 +479,47 @@ export const ContractSDVTTargetValidatorLimitsUpdateV1 = createContractHelpers({
   factory: TypeChain.UpdateTargetValidatorLimitsV1Abi__factory,
   address: EvmAddressesByType[MotionType.SDVTTargetValidatorLimitsUpdateV1],
 })
+
+export const ContractEcosystemOpsStablesAllowedRecipientsRegistry =
+  createContractHelpers({
+    factory: TypeChain.RegistryWithLimitsAbi__factory,
+    address: CONTRACT_ADDRESSES.EcosystemOpsStablesAllowedRecipientsRegistry,
+  })
+
+export const ContractEcosystemOpsStablesTopUp = createContractHelpers({
+  factory: TypeChain.TopUpWithLimitsStablesAbi__factory,
+  address: EvmAddressesByType[MotionType.EcosystemOpsStablesTopUp],
+})
+
+export const ContractLabsOpsStablesAllowedRecipientsRegistry =
+  createContractHelpers({
+    factory: TypeChain.RegistryWithLimitsAbi__factory,
+    address: CONTRACT_ADDRESSES.LabsOpsStablesAllowedRecipientsRegistry,
+  })
+
+export const ContractLabsOpsStablesTopUp = createContractHelpers({
+  factory: TypeChain.TopUpWithLimitsStablesAbi__factory,
+  address: EvmAddressesByType[MotionType.LabsOpsStablesTopUp],
+})
+
+export const ContractEcosystemOpsStethAllowedRecipientsRegistry =
+  createContractHelpers({
+    factory: TypeChain.RegistryWithLimitsAbi__factory,
+    address: CONTRACT_ADDRESSES.EcosystemOpsStethAllowedRecipientsRegistry,
+  })
+
+export const ContractEcosystemOpsStethTopUp = createContractHelpers({
+  factory: TypeChain.TopUpWithLimitsAbi__factory,
+  address: EvmAddressesByType[MotionType.EcosystemOpsStethTopUp],
+})
+
+export const ContractLabsOpsStethAllowedRecipientsRegistry =
+  createContractHelpers({
+    factory: TypeChain.RegistryWithLimitsAbi__factory,
+    address: CONTRACT_ADDRESSES.LabsOpsStethAllowedRecipientsRegistry,
+  })
+
+export const ContractLabsOpsStethTopUp = createContractHelpers({
+  factory: TypeChain.TopUpWithLimitsAbi__factory,
+  address: EvmAddressesByType[MotionType.LabsOpsStethTopUp],
+})

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -270,6 +270,14 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.LegoDAITopUp]: '0xBCcfe42cc3EF530db9888dC8F82B1B4A4DfB9DB4',
     [MotionType.SDVTTargetValidatorLimitsUpdateV1]:
       '0xC91a676A69Eb49be9ECa1954fE6fc861AE07A9A2',
+    [MotionType.EcosystemOpsStablesTopUp]:
+      '0x167caEDde0F3230eB18763270B11c970409F389e',
+    [MotionType.EcosystemOpsStethTopUp]:
+      '0x4F2dA002a7bD5F7C63B62d4C9e4b762c689Dd8Ac',
+    [MotionType.LabsOpsStablesTopUp]:
+      '0xf7304738E9d4F572b909FaEd32504F558E234cdB',
+    [MotionType.LabsOpsStethTopUp]:
+      '0xef0Df040B76252cC7fa31a5fc2f36e85c1C8c4f9',
   },
 }
 

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -290,7 +290,7 @@ export const EvmUnrecognized = 'EvmUnrecognized'
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type EvmUnrecognized = typeof EvmUnrecognized
 
-export const EvmTypesByAdress = mapValues(
+export const EvmTypesByAddress = mapValues(
   flow(
     toPairs,
     map(([type, address]) => [address, type]),

--- a/modules/motions/hooks/useAvailableMotions.ts
+++ b/modules/motions/hooks/useAvailableMotions.ts
@@ -3,7 +3,7 @@ import { utils } from 'ethers'
 
 import { useWeb3 } from 'modules/blockChain/hooks/useWeb3'
 import {
-  EvmTypesByAdress,
+  EvmTypesByAddress,
   parseEvmSupportedChainId,
 } from 'modules/motions/evmAddresses'
 
@@ -105,7 +105,9 @@ export const useAvailableMotions = () => {
           const { contractAddress, trustedCaller } = cur.value
 
           const contractType =
-            EvmTypesByAdress[parseEvmSupportedChainId(chainId)][contractAddress]
+            EvmTypesByAddress[parseEvmSupportedChainId(chainId)][
+              contractAddress
+            ]
 
           if (
             !contractType ||

--- a/modules/motions/hooks/useContractEvmScript.ts
+++ b/modules/motions/hooks/useContractEvmScript.ts
@@ -84,6 +84,11 @@ export const EVM_CONTRACTS = {
     CONTRACTS.ContractEvmAllianceOpsStablesTopUp,
   [MotionType.SDVTTargetValidatorLimitsUpdateV1]:
     CONTRACTS.ContractSDVTTargetValidatorLimitsUpdateV1,
+  [MotionType.EcosystemOpsStablesTopUp]:
+    CONTRACTS.ContractEcosystemOpsStablesTopUp,
+  [MotionType.EcosystemOpsStethTopUp]: CONTRACTS.ContractEcosystemOpsStethTopUp,
+  [MotionType.LabsOpsStablesTopUp]: CONTRACTS.ContractLabsOpsStablesTopUp,
+  [MotionType.LabsOpsStethTopUp]: CONTRACTS.ContractLabsOpsStethTopUp,
 } as const
 
 export function useContractEvmScript<T extends MotionType | EvmUnrecognized>(

--- a/modules/motions/hooks/useEVMScriptDecoder.ts
+++ b/modules/motions/hooks/useEVMScriptDecoder.ts
@@ -63,6 +63,14 @@ export function useEVMScriptDecoder() {
           abis.RegistryWithLimitsAbi__factory.abi,
         [KEYS.AllianceOpsAllowedRecipientsRegistry]:
           abis.RegistryWithLimitsAbi__factory.abi,
+        [KEYS.EcosystemOpsStablesAllowedRecipientsRegistry]:
+          abis.RegistryWithLimitsAbi__factory.abi,
+        [KEYS.EcosystemOpsStethAllowedRecipientsRegistry]:
+          abis.RegistryWithLimitsAbi__factory.abi,
+        [KEYS.LabsOpsStablesAllowedRecipientsRegistry]:
+          abis.RegistryWithLimitsAbi__factory.abi,
+        [KEYS.LabsOpsStethAllowedRecipientsRegistry]:
+          abis.RegistryWithLimitsAbi__factory.abi,
       }),
     )
   }, `evm-script-decoder-${chainId}`)

--- a/modules/motions/hooks/useRegistryWithLimits.ts
+++ b/modules/motions/hooks/useRegistryWithLimits.ts
@@ -21,6 +21,10 @@ import {
   ContractStonksStethAllowedRecipientsRegistry,
   ContractStonksStablesAllowedRecipientsRegistry,
   ContractAllianceOpsStablesAllowedRecipientsRegistry,
+  ContractEcosystemOpsStablesAllowedRecipientsRegistry,
+  ContractEcosystemOpsStethAllowedRecipientsRegistry,
+  ContractLabsOpsStablesAllowedRecipientsRegistry,
+  ContractLabsOpsStethAllowedRecipientsRegistry,
 } from 'modules/blockChain/contracts'
 import { getEventsRecipientAdded } from 'modules/motions/utils'
 import { MotionType } from 'modules/motions/types'
@@ -77,6 +81,13 @@ export const REGISTRY_WITH_LIMITS_BY_MOTION_TYPE = {
     ContractStonksStablesAllowedRecipientsRegistry,
   [MotionType.AllianceOpsStablesTopUp]:
     ContractAllianceOpsStablesAllowedRecipientsRegistry,
+  [MotionType.EcosystemOpsStablesTopUp]:
+    ContractEcosystemOpsStablesAllowedRecipientsRegistry,
+  [MotionType.EcosystemOpsStethTopUp]:
+    ContractEcosystemOpsStethAllowedRecipientsRegistry,
+  [MotionType.LabsOpsStablesTopUp]:
+    ContractLabsOpsStablesAllowedRecipientsRegistry,
+  [MotionType.LabsOpsStethTopUp]: ContractLabsOpsStethAllowedRecipientsRegistry,
 } as const
 
 type HookArgs = {

--- a/modules/motions/hooks/useTokenByTopUpType.ts
+++ b/modules/motions/hooks/useTokenByTopUpType.ts
@@ -74,6 +74,14 @@ const TOKEN = {
     label: 'stETH',
     value: (chainId: CHAINS) => CONTRACT_ADDRESSES.STETH[chainId],
   },
+  [MotionType.EcosystemOpsStethTopUp]: {
+    label: 'stETH',
+    value: (chainId: CHAINS) => CONTRACT_ADDRESSES.STETH[chainId],
+  },
+  [MotionType.LabsOpsStethTopUp]: {
+    label: 'stETH',
+    value: (chainId: CHAINS) => CONTRACT_ADDRESSES.STETH[chainId],
+  },
 }
 
 const isTopUpType = (type: unknown): type is keyof typeof TOKEN => {

--- a/modules/motions/types.ts
+++ b/modules/motions/types.ts
@@ -43,6 +43,10 @@ export const MotionTypeForms = {
   StonksStethTopUp: 'StonksStethTopUp',
   StonksStablesTopUp: 'StonksStablesTopUp',
   AllianceOpsStablesTopUp: 'AllianceOpsStablesTopUp',
+  EcosystemOpsStablesTopUp: 'EcosystemOpsStablesTopUp',
+  EcosystemOpsStethTopUp: 'EcosystemOpsStethTopUp',
+  LabsOpsStablesTopUp: 'LabsOpsStablesTopUp',
+  LabsOpsStethTopUp: 'LabsOpsStethTopUp',
 
   CSMSettleElStealingPenalty: 'CSMSettleElStealingPenalty',
 } as const

--- a/modules/motions/ui/MotionDescription/MotionDescription.tsx
+++ b/modules/motions/ui/MotionDescription/MotionDescription.tsx
@@ -309,6 +309,30 @@ const MOTION_DESCRIPTIONS = {
       registryType={MotionType.AllianceOpsStablesTopUp}
     />
   ),
+  [MotionType.EcosystemOpsStablesTopUp]: (props: GenericDescProps) => (
+    <DescTopUpWithLimitsAndCustomToken
+      {...props}
+      registryType={MotionType.EcosystemOpsStablesTopUp}
+    />
+  ),
+  [MotionType.LabsOpsStablesTopUp]: (props: GenericDescProps) => (
+    <DescTopUpWithLimitsAndCustomToken
+      {...props}
+      registryType={MotionType.LabsOpsStablesTopUp}
+    />
+  ),
+  [MotionType.EcosystemOpsStethTopUp]: (props: DescWithLimitsProps) => (
+    <DescTopUpWithLimits
+      {...props}
+      registryType={MotionType.EcosystemOpsStethTopUp}
+    />
+  ),
+  [MotionType.LabsOpsStethTopUp]: (props: DescWithLimitsProps) => (
+    <DescTopUpWithLimits
+      {...props}
+      registryType={MotionType.StonksStethTopUp}
+    />
+  ),
 } as const
 
 type Props = {

--- a/modules/motions/ui/MotionDescription/MotionDescription.tsx
+++ b/modules/motions/ui/MotionDescription/MotionDescription.tsx
@@ -330,7 +330,7 @@ const MOTION_DESCRIPTIONS = {
   [MotionType.LabsOpsStethTopUp]: (props: DescWithLimitsProps) => (
     <DescTopUpWithLimits
       {...props}
-      registryType={MotionType.StonksStethTopUp}
+      registryType={MotionType.LabsOpsStethTopUp}
     />
   ),
 } as const

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimits.tsx
@@ -35,6 +35,8 @@ import {
   ContractPmlStethTopUp,
   ContractAtcStethTopUp,
   ContractStonksStethTopUp,
+  ContractEcosystemOpsStethTopUp,
+  ContractLabsOpsStethTopUp,
 } from 'modules/blockChain/contracts'
 import { MotionType } from 'modules/motions/types'
 import { createMotionFormPart } from './createMotionFormPart'
@@ -46,7 +48,7 @@ import {
 import { periodLimitError } from 'modules/motions/constants'
 import { validateTransitionLimit } from 'modules/motions/utils/validateTransitionLimit'
 
-export const TOPUP_WITH_LIMITS_MAP = {
+export const TOP_UP_WITH_LIMITS_MAP = {
   [MotionType.LegoLDOTopUp]: {
     evmContract: ContractEvmLegoLDOTopUp,
     motionType: MotionType.LegoLDOTopUp,
@@ -71,6 +73,14 @@ export const TOPUP_WITH_LIMITS_MAP = {
     evmContract: ContractStonksStethTopUp,
     motionType: MotionType.StonksStethTopUp,
   },
+  [MotionType.EcosystemOpsStethTopUp]: {
+    evmContract: ContractEcosystemOpsStethTopUp,
+    motionType: MotionType.EcosystemOpsStethTopUp,
+  },
+  [MotionType.LabsOpsStethTopUp]: {
+    evmContract: ContractLabsOpsStethTopUp,
+    motionType: MotionType.LabsOpsStethTopUp,
+  },
 }
 
 type Program = {
@@ -81,10 +91,10 @@ type Program = {
 export const formParts = ({
   registryType,
 }: {
-  registryType: keyof typeof TOPUP_WITH_LIMITS_MAP
+  registryType: keyof typeof TOP_UP_WITH_LIMITS_MAP
 }) =>
   createMotionFormPart({
-    motionType: TOPUP_WITH_LIMITS_MAP[registryType].motionType,
+    motionType: TOP_UP_WITH_LIMITS_MAP[registryType].motionType,
     populateTx: async ({ evmScriptFactory, formData, contract }) => {
       const encodedCallData = new utils.AbiCoder().encode(
         ['address[]', 'uint256[]'],
@@ -111,7 +121,7 @@ export const formParts = ({
       submitAction,
     }) {
       const { walletAddress } = useWeb3()
-      const trustedCaller = TOPUP_WITH_LIMITS_MAP[
+      const trustedCaller = TOP_UP_WITH_LIMITS_MAP[
         registryType
       ].evmContract.useSwrWeb3('trustedCaller', [])
       const isTrustedCallerConnected = trustedCaller.data === walletAddress

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewTopUpWithLimitsAndCustomToken.tsx
@@ -32,6 +32,8 @@ import {
   ContractLegoStablesTopUp,
   ContractStonksStablesTopUp,
   ContractEvmAllianceOpsStablesTopUp,
+  ContractEcosystemOpsStablesTopUp,
+  ContractLabsOpsStablesTopUp,
 } from 'modules/blockChain/contracts'
 import { MotionType } from 'modules/motions/types'
 import { createMotionFormPart } from './createMotionFormPart'
@@ -47,7 +49,7 @@ import { AddressInlineWithPop } from 'modules/shared/ui/Common/AddressInlineWith
 import { DEFAULT_DECIMALS } from 'modules/blockChain/constants'
 import { validateTransitionLimit } from 'modules/motions/utils/validateTransitionLimit'
 
-export const TOPUP_WITH_LIMITS_MAP = {
+export const TOP_UP_WITH_LIMITS_MAP = {
   [MotionType.RccStablesTopUp]: {
     evmContract: ContractEvmRccStablesTopUp,
     motionType: MotionType.RccStablesTopUp,
@@ -76,6 +78,14 @@ export const TOPUP_WITH_LIMITS_MAP = {
     evmContract: ContractEvmAllianceOpsStablesTopUp,
     motionType: MotionType.AllianceOpsStablesTopUp,
   },
+  [MotionType.EcosystemOpsStablesTopUp]: {
+    evmContract: ContractEcosystemOpsStablesTopUp,
+    motionType: MotionType.EcosystemOpsStablesTopUp,
+  },
+  [MotionType.LabsOpsStablesTopUp]: {
+    evmContract: ContractLabsOpsStablesTopUp,
+    motionType: MotionType.LabsOpsStablesTopUp,
+  },
 }
 
 type Program = {
@@ -86,10 +96,10 @@ type Program = {
 export const formParts = ({
   registryType,
 }: {
-  registryType: keyof typeof TOPUP_WITH_LIMITS_MAP
+  registryType: keyof typeof TOP_UP_WITH_LIMITS_MAP
 }) =>
   createMotionFormPart({
-    motionType: TOPUP_WITH_LIMITS_MAP[registryType].motionType,
+    motionType: TOP_UP_WITH_LIMITS_MAP[registryType].motionType,
     populateTx: async ({ evmScriptFactory, formData, contract }) => {
       const encodedCallData = new utils.AbiCoder().encode(
         ['address', 'address[]', 'uint256[]'],
@@ -121,7 +131,7 @@ export const formParts = ({
       submitAction,
     }) {
       const { walletAddress } = useWeb3()
-      const trustedCaller = TOPUP_WITH_LIMITS_MAP[
+      const trustedCaller = TOP_UP_WITH_LIMITS_MAP[
         registryType
       ].evmContract.useSwrWeb3('trustedCaller', [])
       const isTrustedCallerConnected = trustedCaller.data === walletAddress

--- a/modules/motions/ui/MotionFormStartNew/Parts/index.ts
+++ b/modules/motions/ui/MotionFormStartNew/Parts/index.ts
@@ -126,6 +126,20 @@ export const formParts = {
     StartNewTopUpWithLimitsAndCustomToken.formParts({
       registryType: MotionTypeForms.AllianceOpsStablesTopUp,
     }),
+  [MotionTypeForms.EcosystemOpsStablesTopUp]:
+    StartNewTopUpWithLimitsAndCustomToken.formParts({
+      registryType: MotionTypeForms.EcosystemOpsStablesTopUp,
+    }),
+  [MotionTypeForms.EcosystemOpsStethTopUp]: StartNewTopUpWithLimits.formParts({
+    registryType: MotionTypeForms.EcosystemOpsStethTopUp,
+  }),
+  [MotionTypeForms.LabsOpsStablesTopUp]:
+    StartNewTopUpWithLimitsAndCustomToken.formParts({
+      registryType: MotionTypeForms.LabsOpsStablesTopUp,
+    }),
+  [MotionTypeForms.LabsOpsStethTopUp]: StartNewTopUpWithLimits.formParts({
+    registryType: MotionTypeForms.LabsOpsStethTopUp,
+  }),
 } as const
 
 export type FormData = {

--- a/modules/motions/utils/getMotionType.ts
+++ b/modules/motions/utils/getMotionType.ts
@@ -3,7 +3,7 @@ import { CHAINS } from '@lido-sdk/constants'
 import { MotionType } from '../types'
 import {
   EvmAddressesByChain,
-  EvmTypesByAdress,
+  EvmTypesByAddress,
   EvmUnrecognized,
   parseEvmSupportedChainId,
 } from '../evmAddresses'
@@ -11,7 +11,9 @@ import {
 export const parseScriptFactory = (chainId: CHAINS, scriptFactory: string) => {
   const address = utils.getAddress(scriptFactory)
   if (
-    !EvmTypesByAdress[parseEvmSupportedChainId(chainId)].hasOwnProperty(address)
+    !EvmTypesByAddress[parseEvmSupportedChainId(chainId)].hasOwnProperty(
+      address,
+    )
   ) {
     throw new Error(`Script factory ${address} not recognized`)
   }
@@ -24,7 +26,7 @@ export const getMotionTypeByScriptFactory = (
 ): MotionType | EvmUnrecognized => {
   try {
     return (
-      EvmTypesByAdress[parseEvmSupportedChainId(chainId)][
+      EvmTypesByAddress[parseEvmSupportedChainId(chainId)][
         parseScriptFactory(chainId, scriptFactory)
       ] ?? EvmUnrecognized
     )

--- a/modules/motions/utils/getMotionTypeDisplayName.ts
+++ b/modules/motions/utils/getMotionTypeDisplayName.ts
@@ -73,6 +73,10 @@ export const MotionTypeDisplayNames: Record<
   [MotionType.AllianceOpsStablesTopUp]: 'Top up Alliance Ops stablecoins',
   [MotionType.SDVTTargetValidatorLimitsUpdateV1]:
     'Update target validator limits [deprecated]',
+  [MotionType.EcosystemOpsStablesTopUp]: 'Top up Ecosystem Ops stablecoins',
+  [MotionType.EcosystemOpsStethTopUp]: 'Top up Ecosystem Ops stETH',
+  [MotionType.LabsOpsStablesTopUp]: 'Top up Labs Ops stablecoins',
+  [MotionType.LabsOpsStethTopUp]: 'Top up Labs Ops stETH',
 } as const
 
 export function getMotionTypeDisplayName(


### PR DESCRIPTION
Holesky addresses reference: [docs](https://docs.lido.fi/deployed-contracts/holesky#easy-track-factories-for-token-transfers)
![Screenshot 2025-02-17 at 16 53 14](https://github.com/user-attachments/assets/dd2d0b77-4aef-40f2-963b-a7e353f0a1ce)
