### PR TITLE
feat: add smart fallback it works on 200 with errors in batch requests

### DIFF
--- a/modules/network/utils/fetchWithFallback.ts
+++ b/modules/network/utils/fetchWithFallback.ts
@@ -30,7 +30,10 @@ export const fetchWithFallback: FetchWithFallback = async (
       .startTimer()
     const response = await fetch(input, init)
     end()
-    if (response.status >= 300) throw response.statusText
+    if (response.status >= 300)
+      throw new Error(response.statusText, {
+        cause: [response, await response.text()],
+      })
     return response
   } catch (error) {
     if (!restInputs.length) throw error


### PR DESCRIPTION
### Description

Inprove fallback logic in case rpc api return 2xx (ok), but there is an error fields in response
Add more logs for grafana

### Checklist:

- [x] Checked the changes locally.
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
