### PR TITLE
Fix: add manifest.json CORS config for Safe App integration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -66,6 +66,28 @@ export default {
   async headers() {
     return [
       {
+        source: '/manifest.json',
+        headers: [
+          {
+            key: 'Access-Control-Allow-Origin',
+            value: '*',
+          },
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET',
+          },
+          {
+            key: 'Access-Control-Allow-Headers',
+            value: 'X-Requested-With, content-type, Authorization',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value:
+              'frame-ancestors "self" https://app.safe.global https://app.safe.protofire.io;',
+          },
+        ],
+      },
+      {
         // Apply these headers to all routes in your application.
         source: '/(.*)',
         headers: [


### PR DESCRIPTION

<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Description

When trying to add Hoodi-deployed application to the Safe applications on the dashboard it fails with the CORS error. For it to work well with the Safe, we need to update the CORS configs for that specific file not to expose other resources and set the allowed frame-ancestors to allow [app.safe.global](https://app.safe.global/welcome) and [app.safe.protofire.io](https://app.safe.protofire.io/welcome/accounts) to embed the app.

<!--- Briefly note most valuable changes in what you did and why we need it, even if the task was described in detail in the task tracker. -->

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [x] Checked the changes locally.
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
