### PR TITLE
fix: subgraph dos protection

### DIFF
--- a/pages/api/subgraph.ts
+++ b/pages/api/subgraph.ts
@@ -86,6 +86,17 @@ export default async function subgraph(
       body: req.body,
     })
 
+    if (!upstream.ok) {
+      const errorMessage = await upstream.text()
+      console.error('Error: subgraph request failed', {
+        ...requestInfo,
+        stage: 'ERROR',
+        error: errorMessage,
+      })
+      res.status(upstream.status).send(errorMessage)
+      return
+    }
+
     // Forward the status code
     res.status(upstream.status)
 

--- a/pages/archive.tsx
+++ b/pages/archive.tsx
@@ -69,11 +69,15 @@ export default function ArchivePage() {
           />
         </LoadMoreWrap>
       )}
-      {!initialLoading && error?.message === 'indexing_error' && (
+      {!initialLoading && error && (
         <WarningBox>
           Failed to fetch data from the Subgraph.
-          <br />
-          Maintainers are notified and working on a fix.
+          {error.message === 'indexing_error' && (
+            <>
+              <br />
+              Maintainers are notified and working on a fix.
+            </>
+          )}
         </WarningBox>
       )}
     </Container>


### PR DESCRIPTION
### Changelog

- Use streams instead of `response.json`;
- Limit body size for `/api/subgraph` to 100kb.