### PR TITLE
fix: get motion enact time from subgraph on a preview card

### DIFF
--- a/modules/motions/ui/MotionCardPreview/MotionCardPreview.tsx
+++ b/modules/motions/ui/MotionCardPreview/MotionCardPreview.tsx
@@ -73,7 +73,7 @@ export function MotionCardPreview({ motion }: Props) {
           {isArchived ? (
             <FormattedDate
               format="MMM DD, YYYY"
-              date={motion.startDate + motion.duration}
+              date={motion.enacted_at ?? motion.startDate + motion.duration}
             />
           ) : isPassed ? (
             '—'


### PR DESCRIPTION
### Description

This PR fixes incorrect enacted time for a motion preview card

### Reference
<img width="698" height="614" alt="image" src="https://github.com/user-attachments/assets/f998013b-cc8e-4217-9b33-5410cc906293" />
<img width="734" height="516" alt="image" src="https://github.com/user-attachments/assets/acf8ef8c-2ad1-4071-a130-bb449355f433" />
