### PR TITLE
update v3 factories

### DIFF
--- a/modules/blockChain/contractAddresses.ts
+++ b/modules/blockChain/contractAddresses.ts
@@ -292,7 +292,7 @@ export const SandboxAllowedRecipientsRegistry: ChainAddressMap = {
 
 export const VaultsAdapter: ChainAddressMap = {
   [CHAINS.Mainnet]: '0xe2DE6d2DefF15588a71849c0429101F8ca9FB14D',
-  [CHAINS.Hoodi]: '0xbc2bb8310730f3d2b514cb26f7e0a8776de879ac',
+  [CHAINS.Hoodi]: '0x854CF0D7446Faa7AdDFE557cc8aa9FA9b7017910',
 }
 
 export const VaultHub: ChainAddressMap = {

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -368,26 +368,26 @@ export const EvmAddressesByChain: EvmAddresses = {
       '0x7FCc2901C6C3D62784cB178B14d44445B038f736',
 
     [MotionType.RegisterGroupsInOperatorGrid]:
-      '0xfEF8B796Fea42b3C68E342364Adcf88F1d6145a6',
+      '0x6e8D6e23A46AD61967CDD5C220B67645F46A2D7c',
     [MotionType.RegisterTiersInOperatorGrid]:
       '0x4DF806111AC58e93d90E6D2fBE8522a76be6F499',
     [MotionType.UpdateGroupsShareLimit]:
-      '0x56Ff87F41a8CF795764E15E496124240Ac17695b',
+      '0x99a645A4137ea171Ce4D43c22d30A71251D6Ed7d',
     [MotionType.AlterTiersInOperatorGrid]:
-      '0xF21f98cac0Ba38f02b4d5be1667cc345929E8877',
+      '0x1e71B8E60e0491A212999f3104A06913b77f438e',
     [MotionType.SandboxStethTopUp]:
       '0xE5aE943A3AEFA44AD16438Bc3D2cA7654103F985',
     [MotionType.SandboxStethAdd]: '0x8f05Cc4cC42745E9723E105D38638683f162e1d9',
     [MotionType.SandboxStethRemove]:
       '0x86E10ffC7c67A92e0c5E58ae42945213da43D0c7',
     [MotionType.SetJailStatusInOperatorGrid]:
-      '0x4e5b0187479854e88A5b18c49047636707a26f0d',
+      '0x395E6AF61B6Ba3EC0E72E168A2Ec8204589F357c',
     [MotionType.UpdateVaultsFeesInOperatorGrid]:
-      '0x615D3f028D1CA549d350403Cd6043Cb515BE08BF',
+      '0x2D5b8B082d618A8d5DeFE3f4c2b2869e3f1C1a3D',
     [MotionType.ForceValidatorExitsInVaultHub]:
-      '0x83DfE5Fe8ac8b7DB38c020F4F54BF09b65D92c63',
+      '0x820e9924C2059d37871acd6eccB578e4a3B15c30',
     [MotionType.SocializeBadDebtInVaultHub]:
-      '0xa11906bBBBaC5207b8FDA4F7F294d7EcB8dcc758',
+      '0x01C9dB53D7a87c3e47D537c925921fB735bEe6c9',
     [MotionType.SetLiabilitySharesTargetInVaultHub]:
       '0xc5dCd2A9642ceA9B71A632BF5b8ff52424Ea1B40',
 

--- a/modules/motions/evmAddresses.ts
+++ b/modules/motions/evmAddresses.ts
@@ -423,6 +423,20 @@ export const EvmAddressesByChain: EvmAddresses = {
     [MotionType.RccStablesTopUp]: '',
     [MotionType.PmlStablesTopUp]: '',
     [MotionType.AtcStablesTopUp]: '',
+    [MotionType.RegisterGroupsInOperatorGridPhaseOne]:
+      '0xfEF8B796Fea42b3C68E342364Adcf88F1d6145a6',
+    [MotionType.UpdateGroupsShareLimitPhaseOne]:
+      '0x56Ff87F41a8CF795764E15E496124240Ac17695b',
+    [MotionType.AlterTiersInOperatorGridPhaseOne]:
+      '0xF21f98cac0Ba38f02b4d5be1667cc345929E8877',
+    [MotionType.SetJailStatusInOperatorGridPhaseOne]:
+      '0x4e5b0187479854e88A5b18c49047636707a26f0d',
+    [MotionType.UpdateVaultsFeesInOperatorGridPhaseOne]:
+      '0x615D3f028D1CA549d350403Cd6043Cb515BE08BF',
+    [MotionType.ForceValidatorExitsInVaultHubPhaseOne]:
+      '0x83DfE5Fe8ac8b7DB38c020F4F54BF09b65D92c63',
+    [MotionType.SocializeBadDebtInVaultHubPhaseOne]:
+      '0xa11906bBBBaC5207b8FDA4F7F294d7EcB8dcc758',
   },
 }
 

--- a/modules/motions/hooks/useContractEvmScript.ts
+++ b/modules/motions/hooks/useContractEvmScript.ts
@@ -115,6 +115,20 @@ export const EVM_CONTRACTS = {
     CONTRACTS.ContractSocializeBadDebtInVaultHub,
   [MotionType.SetLiabilitySharesTargetInVaultHub]:
     CONTRACTS.ContractSetLiabilitySharesTargetInVaultHub,
+  [MotionType.RegisterGroupsInOperatorGridPhaseOne]:
+    CONTRACTS.ContractRegisterGroupsInOperatorGrid,
+  [MotionType.UpdateGroupsShareLimitPhaseOne]:
+    CONTRACTS.ContractUpdateGroupsShareLimit,
+  [MotionType.AlterTiersInOperatorGridPhaseOne]:
+    CONTRACTS.ContractAlterTiersInOperatorGrid,
+  [MotionType.SetJailStatusInOperatorGridPhaseOne]:
+    CONTRACTS.ContractSetJailStatusInOperatorGrid,
+  [MotionType.UpdateVaultsFeesInOperatorGridPhaseOne]:
+    CONTRACTS.ContractUpdateVaultsFeesInOperatorGrid,
+  [MotionType.ForceValidatorExitsInVaultHubPhaseOne]:
+    CONTRACTS.ContractForceValidatorExitsInVaultHub,
+  [MotionType.SocializeBadDebtInVaultHubPhaseOne]:
+    CONTRACTS.ContractSocializeBadDebtInVaultHub,
 } as const
 
 export function useContractEvmScript<T extends MotionType | EvmUnrecognized>(

--- a/modules/motions/types.ts
+++ b/modules/motions/types.ts
@@ -95,6 +95,15 @@ export const MotionTypeDisplayOnly = {
   RccStablesTopUp: 'RccStablesTopUp',
   PmlStablesTopUp: 'PmlStablesTopUp',
   AtcStablesTopUp: 'AtcStablesTopUp',
+  RegisterGroupsInOperatorGridPhaseOne: 'RegisterGroupsInOperatorGridPhaseOne',
+  UpdateGroupsShareLimitPhaseOne: 'UpdateGroupsShareLimitPhaseOne',
+  AlterTiersInOperatorGridPhaseOne: 'AlterTiersInOperatorGridPhaseOne',
+  SetJailStatusInOperatorGridPhaseOne: 'SetJailStatusInOperatorGridPhaseOne',
+  UpdateVaultsFeesInOperatorGridPhaseOne:
+    'UpdateVaultsFeesInOperatorGridPhaseOne',
+  ForceValidatorExitsInVaultHubPhaseOne:
+    'ForceValidatorExitsInVaultHubPhaseOne',
+  SocializeBadDebtInVaultHubPhaseOne: 'SocializeBadDebtInVaultHubPhaseOne',
 } as const
 // intentionally
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/modules/motions/ui/MotionDescription/MotionDescription.tsx
+++ b/modules/motions/ui/MotionDescription/MotionDescription.tsx
@@ -373,6 +373,19 @@ const MOTION_DESCRIPTIONS = {
       registryType={MotionType.SandboxStethRemove}
     />
   ),
+  [MotionType.RegisterGroupsInOperatorGridPhaseOne]:
+    DescVaultsRegisterGroupsInOperatorGrid,
+  [MotionType.UpdateGroupsShareLimitPhaseOne]: DescVaultsUpdateGroupsShareLimit,
+  [MotionType.AlterTiersInOperatorGridPhaseOne]:
+    DescVaultsAlterTiersInOperatorGrid,
+  [MotionType.SetJailStatusInOperatorGridPhaseOne]:
+    DescVaultsSetJailStatusInOperatorGrid,
+  [MotionType.UpdateVaultsFeesInOperatorGridPhaseOne]:
+    DescVaultsUpdateVaultsFeesInOperatorGrid,
+  [MotionType.ForceValidatorExitsInVaultHubPhaseOne]:
+    DescVaultsForceValidatorExitsInVaultHub,
+  [MotionType.SocializeBadDebtInVaultHubPhaseOne]:
+    DescVaultsSocializeBadDebtInVaultHub,
 } as const
 
 type Props = {

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewVaultForceValidatorExitsInVaultHub.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewVaultForceValidatorExitsInVaultHub.tsx
@@ -105,6 +105,11 @@ export const formParts = createMotionFormPart({
                   vaultsFieldName={fieldNames.vaults}
                   fieldIndex={fieldIndex}
                   getVaultData={getVaultData}
+                  extraValidateFn={vaultData => {
+                    if (vaultData.isPendingDisconnect) {
+                      return 'Vault is pending disconnect in the Operator Grid'
+                    }
+                  }}
                 />
               </Fieldset>
 

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewVaultsRegisterGroupsInOperatorGrid.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewVaultsRegisterGroupsInOperatorGrid.tsx
@@ -32,6 +32,7 @@ import { InputControl } from 'modules/shared/ui/Controls/Input'
 import { validateAddress } from 'modules/motions/utils/validateAddress'
 import { PredefinedGroupParamsPicker } from 'modules/vaults/ui/PredefinedGroupParamsPicker'
 import { MotionInfoBox } from 'modules/shared/ui/Common/MotionInfoBox'
+import { useOperatorGridGroupMap } from 'modules/vaults/hooks/useOperatorGridGroupMap'
 
 export const formParts = createMotionFormPart({
   motionType: MotionType.RegisterGroupsInOperatorGrid,
@@ -103,6 +104,8 @@ export const formParts = createMotionFormPart({
       initialLoading: isOperatorGridInfoLoading,
     } = useOperatorGridInfo()
 
+    const { getOperatorGridGroup } = useOperatorGridGroupMap()
+
     const groupsFieldArray = useFieldArray({ name: fieldNames.groups })
 
     const { watch } = useFormContext()
@@ -153,7 +156,7 @@ export const formParts = createMotionFormPart({
                     label="Node operator address"
                     rules={{
                       required: 'Field is required',
-                      validate: value => {
+                      validate: async value => {
                         const addressErr = validateAddress(value)
                         if (addressErr) {
                           return addressErr
@@ -173,6 +176,14 @@ export const formParts = createMotionFormPart({
 
                         if (addressInGroupInputIndex !== -1) {
                           return 'Address is already in use by another group within the motion'
+                        }
+
+                        const groupData = await getOperatorGridGroup(
+                          lowerAddress,
+                        )
+
+                        if (groupData) {
+                          return 'Address is already registered in Operator Grid'
                         }
 
                         return true

--- a/modules/motions/ui/MotionFormStartNew/Parts/StartNewVaultsSetLiabilitySharesTargetInVaultHub.tsx
+++ b/modules/motions/ui/MotionFormStartNew/Parts/StartNewVaultsSetLiabilitySharesTargetInVaultHub.tsx
@@ -108,6 +108,11 @@ export const formParts = createMotionFormPart({
                   vaultsFieldName={fieldNames.vaults}
                   fieldIndex={fieldIndex}
                   getVaultData={getVaultData}
+                  extraValidateFn={vaultData => {
+                    if (vaultData.isPendingDisconnect) {
+                      return 'Vault is pending disconnect in the Operator Grid'
+                    }
+                  }}
                 />
               </Fieldset>
 

--- a/modules/motions/utils/getMotionTypeDisplayName.ts
+++ b/modules/motions/utils/getMotionTypeDisplayName.ts
@@ -96,6 +96,20 @@ export const MotionTypeDisplayNames: Record<
   [MotionType.RccStethTopUp]: 'Top up RCC stETH',
   [MotionType.PmlStethTopUp]: 'Top up PML stETH',
   [MotionType.AtcStethTopUp]: 'Top up ATC stETH',
+  [MotionType.RegisterGroupsInOperatorGridPhaseOne]:
+    'Register groups in Operator Grid (Phase I)',
+  [MotionType.UpdateGroupsShareLimitPhaseOne]:
+    'Update groups share limit (Phase I)',
+  [MotionType.AlterTiersInOperatorGridPhaseOne]:
+    'Alter tiers in Operator Grid (Phase I)',
+  [MotionType.SetJailStatusInOperatorGridPhaseOne]:
+    'Set jail status in Operator Grid (Phase I)',
+  [MotionType.UpdateVaultsFeesInOperatorGridPhaseOne]:
+    'Update vaults fees in Operator Grid (Phase I)',
+  [MotionType.ForceValidatorExitsInVaultHubPhaseOne]:
+    'Force validator exits in Vault Hub (Phase I)',
+  [MotionType.SocializeBadDebtInVaultHubPhaseOne]:
+    'Socialize bad debt in Vault Hub (Phase I)',
 } as const
 
 export function getMotionTypeDisplayName(


### PR DESCRIPTION
### Changelog

- update addresses on Hoodi for `VaultsAdapter`, `RegisterGroupsInOperatorGrid`, `UpdateGroupsShareLimit`, `AlterTiersInOperatorGrid`, `SetJailStatusInOperatorGrid`, `UpdateVaultsFeesInOperatorGrid`, `ForceValidatorExitsInVaultHub` and `SocializeBadDebtInVaultHub`;
- update factory forms' validation according to updated code of `VaultsAdapter`;
- add validation to `RegisterGroupsInOperatorGrid`: check if address was already added to `OperatorGrid` before;